### PR TITLE
Cisco FWSM can add protocol to message 106023.

### DIFF
--- a/patterns/firewalls
+++ b/patterns/firewalls
@@ -40,7 +40,7 @@ CISCOFW106015 %{CISCO_ACTION:action} %{WORD:protocol} \(%{DATA:policy_id}\) from
 # ASA-1-106021
 CISCOFW106021 %{CISCO_ACTION:action} %{WORD:protocol} reverse path check from %{IP:src_ip} to %{IP:dst_ip} on interface %{GREEDYDATA:interface}
 # ASA-4-106023
-CISCOFW106023 %{CISCO_ACTION:action} %{WORD:protocol} src %{DATA:src_interface}:%{IP:src_ip}(/%{INT:src_port})?(\(%{DATA:src_fwuser}\))? dst %{DATA:dst_interface}:%{IP:dst_ip}(/%{INT:dst_port})?(\(%{DATA:dst_fwuser}\))?( \(type %{INT:icmp_type}, code %{INT:icmp_code}\))? by access-group %{NOTSPACE:policy_id} \[%{DATA:hashcode1}, %{DATA:hashcode2}\]
+CISCOFW106023 %{CISCO_ACTION:action}( protocol)? %{WORD:protocol} src %{DATA:src_interface}:%{DATA:src_ip}(/%{INT:src_port})?(\(%{DATA:src_fwuser}\))? dst %{DATA:dst_interface}:%{DATA:dst_ip}(/%{INT:dst_port})?(\(%{DATA:dst_fwuser}\))?( \(type %{INT:icmp_type}, code %{INT:icmp_code}\))? by access-group "?%{DATA:policy_id}"? \[%{DATA:hashcode1}, %{DATA:hashcode2}\]
 # ASA-5-106100
 CISCOFW106100 access-list %{NOTSPACE:policy_id} %{CISCO_ACTION:action} %{WORD:protocol} %{DATA:src_interface}/%{IP:src_ip}\(%{INT:src_port}\)(\(%{DATA:src_fwuser}\))? -> %{DATA:dst_interface}/%{IP:dst_ip}\(%{INT:dst_port}\)(\(%{DATA:src_fwuser}\))? hit-cnt %{INT:hit_count} %{CISCO_INTERVAL:interval} \[%{DATA:hashcode1}, %{DATA:hashcode2}\]
 # ASA-6-110002

--- a/spec/patterns/firewalls_spec.rb
+++ b/spec/patterns/firewalls_spec.rb
@@ -50,4 +50,56 @@ describe "FIREWALLS" do
     end
   end
 
+  let(:pattern106023) { "CISCOFW106023" }
+
+  context "parsing a 106023 message" do
+
+    let(:value) { 'Deny tcp src outside:192.168.1.1/50240 dst inside:192.168.1.2/23 by access-group "S_OUTSIDE_TO_INSIDE" [0x54c7fa80, 0x0]' }
+
+    subject { grok_match(pattern106023, value) }
+
+    it 'should break the message up into fields' do
+      expect(subject['action']).to eq('Deny')
+      expect(subject['src_interface']).to eq('outside')
+      expect(subject['dst_interface']).to eq('inside')
+      expect(subject['protocol']).to eq('tcp')
+      expect(subject['src_ip']).to eq('192.168.1.1')
+      expect(subject['dst_ip']).to eq('192.168.1.2')
+      expect(subject['policy_id']).to eq('S_OUTSIDE_TO_INSIDE')
+    end
+  end
+
+  context "parsing a 106023 message with a protocol number" do
+
+    let(:value) { 'Deny protocol 103 src outside:192.168.1.1/50240 dst inside:192.168.1.2/23 by access-group "S_OUTSIDE_TO_INSIDE" [0x54c7fa80, 0x0]' }
+
+    subject { grok_match(pattern106023, value) }
+
+    it 'should break the message up into fields' do
+      expect(subject['action']).to eq('Deny')
+      expect(subject['src_interface']).to eq('outside')
+      expect(subject['dst_interface']).to eq('inside')
+      expect(subject['protocol']).to eq('103')
+      expect(subject['src_ip']).to eq('192.168.1.1')
+      expect(subject['dst_ip']).to eq('192.168.1.2')
+      expect(subject['policy_id']).to eq('S_OUTSIDE_TO_INSIDE')
+    end
+  end
+
+  context "parsing a 106023 message with a hostname" do
+
+    let(:value) { 'Deny tcp src outside:192.168.1.1/50240 dst inside:www.example.com/23 by access-group "S_OUTSIDE_TO_INSIDE" [0x54c7fa80, 0x0]' }
+
+    subject { grok_match(pattern106023, value) }
+
+    it 'should break the message up into fields' do
+      expect(subject['action']).to eq('Deny')
+      expect(subject['src_interface']).to eq('outside')
+      expect(subject['dst_interface']).to eq('inside')
+      expect(subject['protocol']).to eq('tcp')
+      expect(subject['src_ip']).to eq('192.168.1.1')
+      expect(subject['dst_ip']).to eq('www.example.com')
+      expect(subject['policy_id']).to eq('S_OUTSIDE_TO_INSIDE')
+    end
+  end
 end


### PR DESCRIPTION
In the case of a numeric protocol cisco will log 'protocl number'
instead of a protocol string
ie.
Deny protocol 103 src outside:xxx.xxx.xxx.xxx dst inside:xxx.xxx.xxx.xxx by access-group "S_OUTSIDE_TO_INSIDE" [0x54c7fa80, 0x0]
vs
Deny tcp src outside:xxx.xxx.xxx.xxx/48821 dst inside:xxx.xxx.xxx.xxx/25 by access-group "S_OUTSIDE_TO_INSIDE" [0x54c7fa80, 0x0]

This change adds an optional match for the literal word protocol.