### PR TITLE
Fix: Use greedy matching for UNIXPATH pattern

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -31,7 +31,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (?>/(?>[\w_%!$@:.,~-]+|\\.)*)+
+UNIXPATH (/([\w_%!$@:.,~-]+|\\.)*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?


### PR DESCRIPTION
If UNIXPATH is set to using the lazy quantifier, then it stops
backtracking correctly when combined with other greedy regexes.

This fixes issue #13