### PR TITLE
HTML5 spec adds some characters to make a valid URI

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -40,7 +40,7 @@ URIHOST %{IPORHOST}(?::%{POSINT:port})?
 # doesn't turn into %XX
 URIPATH (?:/[A-Za-z0-9$.+!*'(){},~:;=@#%_\-]*)+
 #URIPARAM \?(?:[A-Za-z0-9]+(?:=(?:[^&]*))?(?:&(?:[A-Za-z0-9]+(?:=(?:[^&]*))?)?)*)?
-URIPARAM \?[A-Za-z0-9$.+!*'|(){},~@#%&/=:;_?\-\[\]]*
+URIPARAM \?[A-Za-z0-9$.+!*'|(){},~@#%&/=:;_?\-\[\]<>]*
 URIPATHPARAM %{URIPATH}(?:%{URIPARAM})?
 URI %{URIPROTO}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST})?(?:%{URIPATHPARAM})?
 


### PR DESCRIPTION
for example `<` or `>`

https://html.spec.whatwg.org/.w3c-html-core/urls.html#parsing-urls