### PR TITLE
Fix tests, remove coercion on optional fields, update naming to match AWS

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -49,6 +49,7 @@ Contributors:
 * Vincent Bernat (vincentbernat)
 * olagache
 * xiaclo
+* Ryan O'Keeffe (danielredoak)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/patterns/aws
+++ b/patterns/aws
@@ -1,11 +1,11 @@
-S3_REQUEST_LINE (?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
+S3_REQUEST_LINE (?:%{WORD:method} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
 
-S3_ACCESS_LOG %{WORD:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) (?:%{INT:response:int}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) (?:%{QS:referrer}|-) (?:"?%{QS:agent}"?|-) (?:-|%{NOTSPACE:version_id})
+S3_ACCESS_LOG %{WORD:bucket_owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:remote_ip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) (?:%{INT:http_status:int}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes_sent}|-) (?:%{INT:object_size}|-) (?:%{INT:total_time}|-) (?:%{INT:turnaround_time}|-) (?:%{QS:referrer}|-) (?:"?%{QS:user_agent}"?|-) (?:-|%{NOTSPACE:version_id})
 
 ELB_URIPATHPARAM %{URIPATH:path}(?:%{URIPARAM:params})?
 
-ELB_URI %{URIPROTO:proto}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST:urihost})?(?:%{ELB_URIPATHPARAM})?
+ELB_URI %{URIPROTO:protocol}://(?:%{USER}(?::[^@]*)?@)?(?:%{URIHOST:urihost})?(?:%{ELB_URIPATHPARAM})?
 
-ELB_REQUEST_LINE (?:%{WORD:verb} %{ELB_URI:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
+ELB_REQUEST_LINE (?:%{WORD:method} %{ELB_URI:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
 
-ELB_ACCESS_LOG %{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elb} %{IP:clientip}:%{INT:clientport:int} %{IP:backendip}:%{INT:backendport:int} %{NUMBER:request_processing_time:float} %{NUMBER:backend_processing_time:float} %{NUMBER:response_processing_time:float} %{INT:response:int} %{INT:backend_response:int} %{INT:received_bytes:int} %{INT:bytes:int} "%{ELB_REQUEST_LINE}"
+ELB_ACCESS_LOG %{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elb} %{IP:clientip}:%{INT:clientport:int} %{IP:backendip}:%{INT:backendport:int} %{NUMBER:request_processing_time:float} %{NUMBER:backend_processing_time:float} %{NUMBER:response_processing_time:float} (?:%{INT:elb_status_code}|-) (?:%{INT:backend_status_code}|-) %{INT:received_bytes:int} %{INT:sent_bytes:int} "%{ELB_REQUEST_LINE}"

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -14,49 +14,49 @@ describe LogStash::Patterns::Core do
 
     sample "79a5 mybucket [06/Feb/2014:00:00:38 +0000] 192.0.2.3 79a5 3E57427F3EXAMPLE REST.GET.VERSIONING - \"GET /mybucket?versioning HTTP/1.1\" 200 - 113 - 7 - \"-\" \"S3Console/0.4\" -" do
       insist { subject["tags"] }.nil?
-      insist { subject["owner"] } == "79a5"
+      insist { subject["bucket_owner"] } == "79a5"
       insist { subject["bucket"] } == "mybucket"
       insist { subject["timestamp"] } == "06/Feb/2014:00:00:38 +0000"
-      insist { subject["clientip"] } == "192.0.2.3"
+      insist { subject["remote_ip"] } == "192.0.2.3"
       insist { subject["requester"] } == "79a5"
       insist { subject["request_id"] } == "3E57427F3EXAMPLE"
       insist { subject["operation"] } == "REST.GET.VERSIONING"
       insist { subject["key"] } == '-'
-      insist { subject["verb"] } == "GET"
+      insist { subject["method"] } == "GET"
       insist { subject["request"] } == "/mybucket?versioning"
       insist { subject["httpversion"] } == "1.1"
-      insist { subject["response"] } == 200
+      insist { subject["http_status"] } == 200
       insist { subject["error_code"] }.nil?
-      insist { subject["bytes"] } == 113
+      insist { subject["bytes_sent"] } == "113"
       insist { subject["object_size"] }.nil?
-      insist { subject["request_time_ms"] } == 7
-      insist { subject["turnaround_time_ms"] }.nil?
+      insist { subject["total_time"] } == "7"
+      insist { subject["turnaround_time"] }.nil?
       insist { subject["referrer"] } == "\"-\""
-      insist { subject["agent"] } == "\"S3Console/0.4\""
+      insist { subject["user_agent"] } == "\"S3Console/0.4\""
       insist { subject["version_id"] }.nil?
     end
 
     sample "79a5 mybucket [12/May/2014:07:54:01 +0000] 10.0.1.2 - 7ACC4BE89EXAMPLE REST.GET.OBJECT foo/bar.html \"GET /foo/bar.html HTTP/1.1\" 304 - - 1718 10 - \"-\" \"Mozilla/5.0\" -" do
       insist { subject["tags"] }.nil?
-      insist { subject["owner"] } == "79a5"
+      insist { subject["bucket_owner"] } == "79a5"
       insist { subject["bucket"] } == "mybucket"
       insist { subject["timestamp"] } == "12/May/2014:07:54:01 +0000"
-      insist { subject["clientip"] } == "10.0.1.2"
+      insist { subject["remote_ip"] } == "10.0.1.2"
       insist { subject["requester"] } == "-"
       insist { subject["request_id"] } == "7ACC4BE89EXAMPLE"
       insist { subject["operation"] } == "REST.GET.OBJECT"
       insist { subject["key"] } == "foo/bar.html"
-      insist { subject["verb"] } == "GET"
+      insist { subject["method"] } == "GET"
       insist { subject["request"] } == "/foo/bar.html"
       insist { subject["httpversion"] } == "1.1"
-      insist { subject["response"] } == 304
+      insist { subject["http_status"] } == 304
       insist { subject["error_code"] }.nil?
-      insist { subject["bytes"] }.nil?
-      insist { subject["object_size"] } == 1718
-      insist { subject["request_time_ms"] } == 10
-      insist { subject["turnaround_time_ms"] }.nil?
+      insist { subject["bytes_sent"] }.nil?
+      insist { subject["object_size"] } == "1718"
+      insist { subject["total_time"] } == "10"
+      insist { subject["turnaround_time"] }.nil?
       insist { subject["referrer"] } == "\"-\""
-      insist { subject["agent"] } == "\"Mozilla/5.0\""
+      insist { subject["user_agent"] } == "\"Mozilla/5.0\""
       insist { subject["version_id"] }.nil?
     end
   end
@@ -81,16 +81,40 @@ describe LogStash::Patterns::Core do
       insist { subject["request_processing_time"] } == 0.000073
       insist { subject["backend_processing_time"] } == 0.001048
       insist { subject["response_processing_time"] } == 0.000057
-      insist { subject["response"] } == 200
-      insist { subject["backend_response"] } == 200
+      insist { subject["elb_status_code"] } == "200"
+      insist { subject["backend_status_code"] } == "200"
       insist { subject["received_bytes"] } == 0
-      insist { subject["bytes"] } == 29
-      insist { subject["verb"] } == "GET"
+      insist { subject["sent_bytes"] } == 29
+      insist { subject["method"] } == "GET"
       insist { subject["request"] } == "http://www.example.com:80/"
-      insist { subject["proto"] } == "http"
+      insist { subject["protocol"] } == "http"
       insist { subject["httpversion"] } == "1.1"
       insist { subject["urihost"] } == "www.example.com:80"
       insist { subject["path"] } == "/"
+      insist { subject["params"] }.nil?
+    end
+
+    sample "2015-03-25T19:43:47.565341Z my-test-tcp-loadbalancer 192.168.131.39:2817 10.0.0.1:80 0.000907 0.00001 0.000015 - - 25 0 \"- - - \"" do
+      insist { subject["tags"] }.nil?
+      insist { subject["timestamp"] } == "2015-03-25T19:43:47.565341Z"
+      insist { subject["elb"] } == "my-test-tcp-loadbalancer"
+      insist { subject["clientip"] } == "192.168.131.39"
+      insist { subject["clientport"] } == 2817
+      insist { subject["backendip"] } == "10.0.0.1"
+      insist { subject["backendport"] } == 80
+      insist { subject["request_processing_time"] } == 0.000907
+      insist { subject["backend_processing_time"] } == 0.00001
+      insist { subject["response_processing_time"] } == 0.000015
+      insist { subject["elb_status_code"] }.nil?
+      insist { subject["backend_status_code"] }.nil?
+      insist { subject["received_bytes"] } == 25
+      insist { subject["sent_bytes"] } == 0
+      insist { subject["method"] }.nil?
+      insist { subject["request"] }.nil?
+      insist { subject["protocol"] }.nil?
+      insist { subject["httpversion"] }.nil?
+      insist { subject["urihost"] }.nil?
+      insist { subject["path"] }.nil?
       insist { subject["params"] }.nil?
     end
   end


### PR DESCRIPTION
Updated s3 and elb field names to match AWS specified names, add matching for TCP ELB logs, remove coercion from optional fields. Test pass with changes

Personally I feel it is best to match the field naming outlined by AWS for the S3 (http://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html) and ELB (http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/access-log-collection.html) formats.
