### PR TITLE
Make pattern specs easier to write

### DIFF
--- a/logstash-patterns-core.gemspec
+++ b/logstash-patterns-core.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-filter-grok'
 end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,11 +1,20 @@
 # encoding: utf-8
-def test_message(pattern_name, sample_message)
+def grok(pattern_name, sample_message, fields = {})
   describe pattern_name do
-    before(:each) { grok.register; grok.filter(event) }
-    let(:grok) { LogStash::Filters::Grok.new("match" => ["message", "%{#{subject}}"]) }
+    before(:each) { grok_obj.register; grok_obj.filter(event) }
+    let(:grok_obj) { LogStash::Filters::Grok.new("match" => ["message", "%{#{pattern_name}}"]) }
     let(:event) { LogStash::Event.new("message" => sample_message) }
-    it "matches a sample line" do
-      expect(event.to_hash).to_not include("tags")
+
+    context "testing line \"#{sample_message}\"" do
+      it "matches" do
+        expect(event.to_hash).to_not include("tags")
+      end
+
+      if !fields.empty?
+        it "has expected fields \"#{fields.inspect}\"" do
+          expect(event.to_hash).to include(fields)
+        end
+      end
     end
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+def test_message(pattern_name, sample_message)
+  describe pattern_name do
+    before(:each) { grok.register; grok.filter(event) }
+    let(:grok) { LogStash::Filters::Grok.new("match" => ["message", "%{#{subject}}"]) }
+    let(:event) { LogStash::Event.new("message" => sample_message) }
+    it "matches a sample line" do
+      expect(event.to_hash).to_not include("tags")
+    end
+  end
+end

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
-require 'logstash/patterns/core'
+require "logstash/patterns/core"
+require "logstash/filters/grok"
+require "spec/helper"
 
-describe LogStash::Patterns::Core do
-end
+test_message "IPORHOST", "127.0.0.1"

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -3,5 +3,3 @@ require "logstash/devutils/rspec/spec_helper"
 require "logstash/patterns/core"
 require "logstash/filters/grok"
 require "spec/helper"
-
-test_message "IPORHOST", "127.0.0.1"


### PR DESCRIPTION
This PR creates a helper that provides the user the following interface:

Putting this in `spec/patterns/core_spec.rb`:

```ruby
grok "IPORHOST", "127.0.0.1"
grok "NAGIOS_TIMEPERIOD_TRANSITION", "TIMEPERIOD TRANSITION: 24x7_sans_holidays;-1;1", {"nagios_type" => "TIMEPERIOD TRANSITION" }
```

and running rspec gives you:

```
% bundle exec rspec --format=documentation
Using Accessor#strict_set for specs
Run options: exclude {:redis=>true, :socket=>true, :performance=>true, :couchdb=>true, :elasticsearch=>true, :elasticsearch_secure=>true, :broken=>true, :export_cypher=>true, :integration=>true, :windows=>true}

NAGIOS_TIMEPERIOD_TRANSITION
  testing line "TIMEPERIOD TRANSITION: 24x7_sans_holidays;-1;1"
    matches
    has expected fields "{"nagios_type"=>"TIMEPERIOD TRANSITION"}"

IPORHOST
  testing line "127.0.0.1"
    matches

Finished in 0.34 seconds
3 examples, 0 failures
```

I don't consider this a final proposal but an idea to improve grok specs writing.