### PR TITLE
Provide a simple way to run grok patterns in test

### DIFF
--- a/logstash-patterns-core.gemspec
+++ b/logstash-patterns-core.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-patterns-core'
-  s.version         = '0.1.7'
+  s.version         = '0.1.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Patterns to be used in logstash"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
+  s.add_development_dependency 'logstash-filter-grok'
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -1,6 +1,31 @@
 # encoding: utf-8
-require "logstash/devutils/rspec/spec_helper"
-require 'logstash/patterns/core'
+require "spec_helper"
+require "logstash/patterns/core"
 
-describe LogStash::Patterns::Core do
+describe "SYSLOGLINE" do
+
+  let(:value)   { "Mar 16 00:01:25 evita postfix/smtpd[1713]: connect from camomile.cloud9.net[168.100.1.3]" }
+  let(:grok)    { grok_match(subject, value) }
+  it "a pattern pass the grok expression" do
+    expect(grok).to pass
+  end
+
+  it "matches a simple message" do
+    expect(subject).to match(value)
+  end
+
+  it "generates the program field" do
+    expect(grok_match(subject, value)).to include("program" => "postfix/smtpd")
+  end
+
+end
+
+describe "COMMONAPACHELOG" do
+
+  let(:value) { '83.149.9.216 - - [24/Feb/2015:23:13:42 +0000] "GET /presentations/logstash-monitorama-2013/images/kibana-search.png HTTP/1.1" 200 203023 "http://semicomplete.com/presentations/logstash-monitorama-2013/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36'}
+
+  it "generates the clientip field" do
+    expect(grok_match(subject, value)).to include("clientip" => "83.149.9.216")
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,42 @@
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/filters/grok"
+require 'rspec/expectations'
+
+module GrokHelpers
+  def grok_match(label, message)
+    grok  = build_grok(label)
+    event = build_event(message)
+    grok.filter(event)
+    event.to_hash
+  end
+
+  def build_grok(label)
+    grok = LogStash::Filters::Grok.new("match" => ["message", "%{#{label}}"])
+    grok.register
+    grok
+  end
+
+  def build_event(message)
+    LogStash::Event.new("message" => message)
+  end
+end
+
+RSpec.configure do |c|
+  c.include GrokHelpers
+end
+
+RSpec::Matchers.define :pass do |expected|
+  match do |actual|
+    !actual.include?("tags")
+  end
+end
+
+RSpec::Matchers.define :match do |value|
+  match do |grok|
+    grok  = build_grok(grok)
+    event = build_event(value)
+    grok.filter(event)
+    !event.include?("tags")
+  end
+end
+


### PR DESCRIPTION
This PR provide a set of helpers useful to test grok expressions. It relates to #24, but in this PR the helpers created use the RSpec DSL without interfering with it, so anyone can actually use this helpers in other context if extended.

It also provide an example of simple and basic custom matcher that simplify the process of checking for the outcome of a test example.