### PR TITLE
Added support for MongoDB version 3 kind of logs

### DIFF
--- a/logstash-patterns-core.gemspec
+++ b/logstash-patterns-core.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-patterns-core'
-  s.version         = '0.1.8'
+  s.version         = '0.1.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Patterns to be used in logstash"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/patterns/mongodb
+++ b/patterns/mongodb
@@ -2,3 +2,6 @@ MONGO_LOG %{SYSLOGTIMESTAMP:timestamp} \[%{WORD:component}\] %{GREEDYDATA:messag
 MONGO_QUERY \{ (?<={ ).*(?= } ntoreturn:) \}
 MONGO_SLOWQUERY %{WORD} %{MONGO_WORDDASH:database}\.%{MONGO_WORDDASH:collection} %{WORD}: %{MONGO_QUERY:query} %{WORD}:%{NONNEGINT:ntoreturn} %{WORD}:%{NONNEGINT:ntoskip} %{WORD}:%{NONNEGINT:nscanned}.*nreturned:%{NONNEGINT:nreturned}..+ (?<duration>[0-9]+)ms
 MONGO_WORDDASH \b[\w-]+\b
+MONGO3_SEVERITY \w
+MONGO3_COMPONENT %{WORD}|-
+MONGO3_LOG %{TIMESTAMP_ISO8601:timestamp} %{MONGO3_SEVERITY:severity} %{MONGO3_COMPONENT:component}%{SPACE}(?:\[%{DATA:context}\])? %{GREEDYDATA:message}

--- a/spec/patterns/mongodb_spec.rb
+++ b/spec/patterns/mongodb_spec.rb
@@ -1,0 +1,84 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/patterns/core"
+
+describe "MONGO3_LOG" do
+
+  let(:pattern)    { "MONGO3_LOG" }
+
+  context "parsing an standard/basic message" do
+
+    let(:value) { "2014-11-03T18:28:32.450-0500 I NETWORK [initandlisten] waiting for connections on port 27017" }
+
+    subject     { grok_match(pattern, value) }
+
+    it { should include("timestamp" => "2014-11-03T18:28:32.450-0500") }
+
+    it { should include("severity" => "I") }
+
+    it { should include("component" => "NETWORK") }
+
+    it { should include("context" => "initandlisten") }
+
+    it "generates a message field" do
+      expect(subject["message"]).to include("waiting for connections on port 27017")
+    end
+  end
+
+  context "parsing a message with a missing component" do
+
+    let(:value) { "2015-02-24T18:17:47.148+0000 F -        [conn11] Got signal: 11 (Segmentation fault)." }
+
+    subject     { grok_match(pattern, value) }
+
+    it { should include("timestamp" => "2015-02-24T18:17:47.148+0000") }
+
+    it { should include("severity" => "F") }
+
+    it { should include("component" => "-") }
+
+    it { should include("context" => "conn11") }
+
+    it "generates a message field" do
+      expect(subject["message"]).to include("Got signal: 11 (Segmentation fault).")
+    end
+  end
+
+  context "parsing a message with a multiwords context" do
+
+    let(:value) { "2015-04-23T06:57:28.256+0200 I JOURNAL  [journal writer] Journal writer thread started" }
+
+    subject     { grok_match(pattern, value) }
+
+    it { should include("timestamp" => "2015-04-23T06:57:28.256+0200") }
+
+    it { should include("severity" => "I") }
+
+    it { should include("component" => "JOURNAL") }
+
+    it { should include("context" => "journal writer") }
+
+    it "generates a message field" do
+      expect(subject["message"]).to include("Journal writer thread started")
+    end
+  end
+
+  context "parsing a message without context" do
+
+    let(:value) { "2015-04-23T07:00:13.864+0200 I CONTROL  Ctrl-C signal" }
+
+    subject     { grok_match(pattern, value) }
+
+    it { should include("timestamp" => "2015-04-23T07:00:13.864+0200") }
+
+    it { should include("severity" => "I") }
+
+    it { should include("component" => "CONTROL") }
+
+    it { should_not have_key("context") }
+
+    it "generates a message field" do
+      expect(subject["message"]).to include("Ctrl-C signal")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #28 

MongoDB v3 add a new format for logs as stated in http://docs.mongodb.org/manual/reference/log-messages/
