### PR TITLE
make field progname optional as it is not always supplied

### DIFF
--- a/patterns/linux-syslog
+++ b/patterns/linux-syslog
@@ -1,6 +1,6 @@
 SYSLOG5424PRINTASCII [!-~]+
 
-SYSLOGBASE2 (?:%{SYSLOGTIMESTAMP:timestamp}|%{TIMESTAMP_ISO8601:timestamp8601}) (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource} %{SYSLOGPROG}:
+SYSLOGBASE2 (?:%{SYSLOGTIMESTAMP:timestamp}|%{TIMESTAMP_ISO8601:timestamp8601}) (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource}+(?: %{SYSLOGPROG}:|)
 SYSLOGPAMSESSION %{SYSLOGBASE} (?=%{GREEDYDATA:message})%{WORD:pam_module}\(%{DATA:pam_caller}\): session %{WORD:pam_session_state} for user %{USERNAME:username}(?: by %{GREEDYDATA:pam_by})?
 
 CRON_ACTION [A-Z ]+


### PR DESCRIPTION
I am receiving messages like the following from a synology nas device: 

<14>Jun 24 10:32:02 hostname WinFileService Event: read, Path: /.DS_Store, File/Folder: File, Size: 6.00 KB, User: user@host, IP: 123.123.123.123

as you can see they do not contain the program part of the syslog message, so i made it optional in the parser. I dont see any disadvantages but i am not sure if the syntax is optimal.