### PR TITLE
Support TIMESTAMP_ISO8601 in HAProxy patterns

### DIFF
--- a/patterns/haproxy
+++ b/patterns/haproxy
@@ -13,8 +13,8 @@ HAPROXYCAPTUREDRESPONSEHEADERS %{DATA:captured_response_headers}
 
 # Example:
 #  These haproxy config lines will add data to the logs that are captured
-#  by the patterns below. Place them in your custom patterns directory to 
-#  override the defaults.  
+#  by the patterns below. Place them in your custom patterns directory to
+#  override the defaults.
 #
 #  capture request header Host len 40
 #  capture request header X-Forwarded-For len 50
@@ -26,14 +26,14 @@ HAPROXYCAPTUREDRESPONSEHEADERS %{DATA:captured_response_headers}
 #  capture response header Content-Encoding len 10
 #  capture response header Cache-Control len 200
 #  capture response header Last-Modified len 200
-# 
+#
 # HAPROXYCAPTUREDREQUESTHEADERS %{DATA:request_header_host}\|%{DATA:request_header_x_forwarded_for}\|%{DATA:request_header_accept_language}\|%{DATA:request_header_referer}\|%{DATA:request_header_user_agent}
 # HAPROXYCAPTUREDRESPONSEHEADERS %{DATA:response_header_content_type}\|%{DATA:response_header_content_encoding}\|%{DATA:response_header_cache_control}\|%{DATA:response_header_last_modified}
 
-# parse a haproxy 'httplog' line 
+# parse a haproxy 'httplog' line
 HAPROXYHTTPBASE %{IP:client_ip}:%{INT:client_port} \[%{HAPROXYDATE:accept_date}\] %{NOTSPACE:frontend_name} %{NOTSPACE:backend_name}/%{NOTSPACE:server_name} %{INT:time_request}/%{INT:time_queue}/%{INT:time_backend_connect}/%{INT:time_backend_response}/%{NOTSPACE:time_duration} %{INT:http_status_code} %{NOTSPACE:bytes_read} %{DATA:captured_request_cookie} %{DATA:captured_response_cookie} %{NOTSPACE:termination_state} %{INT:actconn}/%{INT:feconn}/%{INT:beconn}/%{INT:srvconn}/%{NOTSPACE:retries} %{INT:srv_queue}/%{INT:backend_queue} (\{%{HAPROXYCAPTUREDREQUESTHEADERS}\})?( )?(\{%{HAPROXYCAPTUREDRESPONSEHEADERS}\})?( )?"(<BADREQ>|(%{WORD:http_verb} (%{URIPROTO:http_proto}://)?(?:%{USER:http_user}(?::[^@]*)?@)?(?:%{URIHOST:http_host})?(?:%{URIPATHPARAM:http_request})?( HTTP/%{NUMBER:http_version})?))?"
 
-HAPROXYHTTP %{SYSLOGTIMESTAMP:syslog_timestamp} %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{HAPROXYHTTPBASE}
+HAPROXYHTTP (?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:timestamp8601}) %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{HAPROXYHTTPBASE}
 
 # parse a haproxy 'tcplog' line
-HAPROXYTCP %{SYSLOGTIMESTAMP:syslog_timestamp} %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{IP:client_ip}:%{INT:client_port} \[%{HAPROXYDATE:accept_date}\] %{NOTSPACE:frontend_name} %{NOTSPACE:backend_name}/%{NOTSPACE:server_name} %{INT:time_queue}/%{INT:time_backend_connect}/%{NOTSPACE:time_duration} %{NOTSPACE:bytes_read} %{NOTSPACE:termination_state} %{INT:actconn}/%{INT:feconn}/%{INT:beconn}/%{INT:srvconn}/%{NOTSPACE:retries} %{INT:srv_queue}/%{INT:backend_queue}
+HAPROXYTCP (?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:timestamp8601}) %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{IP:client_ip}:%{INT:client_port} \[%{HAPROXYDATE:accept_date}\] %{NOTSPACE:frontend_name} %{NOTSPACE:backend_name}/%{NOTSPACE:server_name} %{INT:time_queue}/%{INT:time_backend_connect}/%{NOTSPACE:time_duration} %{NOTSPACE:bytes_read} %{NOTSPACE:termination_state} %{INT:actconn}/%{INT:feconn}/%{INT:beconn}/%{INT:srvconn}/%{NOTSPACE:retries} %{INT:srv_queue}/%{INT:backend_queue}

--- a/spec/patterns/haproxy_spec.rb
+++ b/spec/patterns/haproxy_spec.rb
@@ -8,7 +8,23 @@ describe "HAPROXY" do
 
   context "Parsing HAPROXY log line from raw syslog line" do
 
-    let(:value) { 'Dec  9 13:01:26 localhost haproxy[28029]: 127.0.0.1:39759 [09/Dec/2013:12:59:46.633] loadbalancer default/instance8 0/51536/1/48082/99627 200 83285 - - ---- 87/87/87/1/0 0/67 {77.24.148.74} "GET /path/to/image HTTP/1.1"' } 
+    let(:value) { 'Dec  9 13:01:26 localhost haproxy[28029]: 127.0.0.1:39759 [09/Dec/2013:12:59:46.633] loadbalancer default/instance8 0/51536/1/48082/99627 200 83285 - - ---- 87/87/87/1/0 0/67 {77.24.148.74} "GET /path/to/image HTTP/1.1"' }
+    subject     { grok_match(haproxyhttp_pattern, value) }
+
+    it { should include("program" => "haproxy") }
+    it { should include("client_ip" => "127.0.0.1") }
+    it { should include("http_verb" => "GET") }
+    it { should include("server_name" => "instance8") }
+
+    it "generates a message field" do
+      expect(subject["message"]).to include("loadbalancer default/instance8")
+    end
+
+  end
+
+  context "Parsing HAPROXY log line from raw syslog line with ISO8601 timestamp" do
+
+    let(:value) { '2015-08-26T02:09:48+02:00 localhost haproxy[28029]: 127.0.0.1:39759 [09/Dec/2013:12:59:46.633] loadbalancer default/instance8 0/51536/1/48082/99627 200 83285 - - ---- 87/87/87/1/0 0/67 {77.24.148.74} "GET /path/to/image HTTP/1.1"' }
     subject     { grok_match(haproxyhttp_pattern, value) }
 
     it { should include("program" => "haproxy") }
@@ -26,7 +42,7 @@ describe "HAPROXY" do
 
   context "Parsing HAPROXY log line without syslog specific enteries.  This mimics an event coming from a syslog input." do
 
-    let(:value) { '127.0.0.1:39759 [09/Dec/2013:12:59:46.633] loadbalancer default/instance8 0/51536/1/48082/99627 200 83285 - - ---- 87/87/87/1/0 0/67 {77.24.148.74} "GET /path/to/image HTTP/1.1"' } 
+    let(:value) { '127.0.0.1:39759 [09/Dec/2013:12:59:46.633] loadbalancer default/instance8 0/51536/1/48082/99627 200 83285 - - ---- 87/87/87/1/0 0/67 {77.24.148.74} "GET /path/to/image HTTP/1.1"' }
     subject     { grok_match(haproxyhttpbase_pattern, value) }
 
     # Assume 'program' would be matched by the syslog input.


### PR DESCRIPTION
Rsyslog (and probably others) can be configured to use ISO8601
timestamps, usually high-precision with microsecond resolution. The
HAProxy patterns should take this possibility into account and not be
arbitrarily limited to just SYSLOGTIMESTAMP.