### PR TITLE
COMMONAPACHELOG: match email address in auth field

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -90,7 +90,7 @@ QS %{QUOTEDSTRING}
 
 # Log formats
 SYSLOGBASE %{SYSLOGTIMESTAMP:timestamp} (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource} %{SYSLOGPROG}:
-COMMONAPACHELOG %{IPORHOST:clientip} %{HTTPDUSER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
+COMMONAPACHELOG %{IPORHOST:clientip} %{HTTPDUSER:ident} %{HTTPDUSER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
 COMBINEDAPACHELOG %{COMMONAPACHELOG} %{QS:referrer} %{QS:agent}
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:loglevel}\] (?:\[client %{IPORHOST:clientip}\] ){0,1}%{GREEDYDATA:errormsg}
 HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:module}:%{LOGLEVEL:loglevel}\] \[pid %{POSINT:pid}:tid %{NUMBER:tid}\]( \(%{POSINT:proxy_errorcode}\)%{DATA:proxy_errormessage}:)?( \[client %{IPORHOST:client}:%{POSINT:clientport}\])? %{DATA:errorcode}: %{GREEDYDATA:message}

--- a/spec/patterns/httpd_spec.rb
+++ b/spec/patterns/httpd_spec.rb
@@ -12,6 +12,10 @@ describe "COMBINEDAPACHELOG" do
     expect(subject).to match("1.2.3.4 - an.email@address.com [22/Sep/2015:14:39:21 +0000] \"GET /index.html\" 200 182 \"https://my.website.com/index.html\" \"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36\"")
   end
 
+  it "matches a username in the ident and auth fields" do
+    expect(subject).to match("1.2.3.4 log.Stash_1 Patterns-Core [22/Sep/2015:14:39:21 +0000] \"GET /index.html\" 200 182 \"https://my.website.com/index.html\" \"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36\"")
+  end
+
 end
 
 describe "HTTPD_ERRORLOG" do

--- a/spec/patterns/httpd_spec.rb
+++ b/spec/patterns/httpd_spec.rb
@@ -2,6 +2,18 @@
 require "spec_helper"
 require "logstash/patterns/core"
 
+describe "COMBINEDAPACHELOG" do
+
+  it "matches an email address in the ident field" do
+    expect(subject).to match("1.2.3.4 an.email@address.com - [22/Sep/2015:14:39:21 +0000] \"GET /index.html\" 200 182 \"https://my.website.com/index.html\" \"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36\"")
+  end
+
+  it "matches an email address in the auth field" do
+    expect(subject).to match("1.2.3.4 - an.email@address.com [22/Sep/2015:14:39:21 +0000] \"GET /index.html\" 200 182 \"https://my.website.com/index.html\" \"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36\"")
+  end
+
+end
+
 describe "HTTPD_ERRORLOG" do
 
   it "matches a full httpd 2.4 message" do


### PR DESCRIPTION
#3 matches email addresses in the `ident` field.  Also allow email addresses in the `auth` field.