### PR TITLE
Add ampersand to URIPATH

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -40,7 +40,7 @@ URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?
 URIHOST %{IPORHOST}(?::%{POSINT:port})?
 # uripath comes loosely from RFC1738, but mostly from what Firefox
 # doesn't turn into %XX
-URIPATH (?:/[A-Za-z0-9$.+!*'(){},~:;=@#%_\-]*)+
+URIPATH (?:/[A-Za-z0-9$.+!*'(){},~:;=@#%&_\-]*)+
 #URIPARAM \?(?:[A-Za-z0-9]+(?:=(?:[^&]*))?(?:&(?:[A-Za-z0-9]+(?:=(?:[^&]*))?)?)*)?
 URIPARAM \?[A-Za-z0-9$.+!*'|(){},~@#%&/=:;_?\-\[\]<>]*
 URIPATHPARAM %{URIPATH}(?:%{URIPARAM})?

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -113,6 +113,62 @@ describe "UNIXPATH" do
   end
 end
 
+describe "URIPATH" do
+  let(:pattern) { 'URIPATH' }
+
+  context "when matching valid URIs" do
+    context "and the URI is simple" do
+      let(:value) { '/foo' }
+
+      it "should match the path" do
+        expect(grok_match(pattern,value)).to pass
+      end
+    end
+
+    context "and the URI has a trailing slash" do
+      let(:value) { '/foo/' }
+
+      it "should match the path" do
+        expect(grok_match(pattern,value)).to pass
+      end
+    end
+
+    context "and the URI has multiple levels" do
+      let(:value) { '/foo/bar' }
+
+      it "should match the path" do
+        expect(grok_match(pattern,value)).to pass
+      end
+    end
+
+    context "and the URI has fancy characters" do
+      let(:value) { '/aA1$.+!*\'(){},~:;=@#%&|-' }
+
+      it "should match the path" do
+        expect(grok_match(pattern,value)).to pass
+      end
+    end
+  end
+
+  context "when matching invalid URIs" do
+    context "and the URI has no leading slash" do
+      let(:value) { 'foo' }
+
+      it "should not match the path" do
+        expect(grok_match(pattern,value)).not_to pass
+      end
+    end
+
+    context "and the URI has invalid characters" do
+      let(:value) { '/`' }
+
+      it "should not match the path" do
+        expect(grok_match(pattern,value)).not_to pass
+      end
+    end
+  end
+end
+
 describe "IPV4" do
 
   let(:pattern) { 'IPV4' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ module GrokHelpers
   end
 
   def build_grok(label)
-    grok = LogStash::Filters::Grok.new("match" => ["message", "%{#{label}}"])
+    grok = LogStash::Filters::Grok.new("match" => ["message", "\A%{#{label}}\z"])
     grok.register
     grok
   end


### PR DESCRIPTION
[RFC1738](http://tools.ietf.org/html/rfc1738#page-18) specifies that URL paths can legally contain ampersands:

    ; HTTP

    httpurl        = "http://" hostport [ "/" hpath [ "?" search ]]
    hpath          = hsegment *[ "/" hsegment ]
    hsegment       = *[ uchar | ";" | ":" | "@" | "&" | "=" ]
    search         = *[ uchar | ";" | ":" | "@" | "&" | "=" ]

Accordingly, HAProxy (and potentially other applications) will not escape them in log files.

Fixes #54.