### PR TITLE
Add URN pattern

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -18,6 +18,8 @@ DATA .*?
 GREEDYDATA .*
 QUOTEDSTRING (?>(?<!\\)(?>"(?>\\.|[^\\"]+)+"|""|(?>'(?>\\.|[^\\']+)+')|''|(?>`(?>\\.|[^\\`]+)+`)|``))
 UUID [A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}
+# URN, allowing use of RFC 2141 section 2.3 reserved characters
+URN urn:[0-9A-Za-z][0-9A-Za-z-]{0,31}:(?:%[0-9a-fA-F]{2}|[0-9A-Za-z()+,.:=@;$_!*'-/?#])+
 
 # Networking
 MAC (?:%{CISCOMAC}|%{WINDOWSMAC}|%{COMMONMAC})

--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -19,7 +19,7 @@ GREEDYDATA .*
 QUOTEDSTRING (?>(?<!\\)(?>"(?>\\.|[^\\"]+)+"|""|(?>'(?>\\.|[^\\']+)+')|''|(?>`(?>\\.|[^\\`]+)+`)|``))
 UUID [A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}
 # URN, allowing use of RFC 2141 section 2.3 reserved characters
-URN urn:[0-9A-Za-z][0-9A-Za-z-]{0,31}:(?:%[0-9a-fA-F]{2}|[0-9A-Za-z()+,.:=@;$_!*'-/?#])+
+URN urn:[0-9A-Za-z][0-9A-Za-z-]{0,31}:(?:%[0-9a-fA-F]{2}|[0-9A-Za-z()+,.:=@;$_!*'/?#-])+
 
 # Networking
 MAC (?:%{CISCOMAC}|%{WINDOWSMAC}|%{COMMONMAC})

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -137,5 +137,92 @@ describe "IPV4" do
       expect(grok_match(pattern,value)).not_to pass
     end
   end
+end
 
+describe "URN" do
+
+  let(:pattern)       { "URN" }
+
+  # Valid URNs
+  # http://tools.ietf.org/html/rfc2141#section-2
+  let(:simple)        { "urn:example:foo" }
+  let(:unreserved)    { "urn:example:" +
+    [*'A'..'Z', *'a'..'z', *'0'..'9', "()+,-.::=@;$_!*'"].join() }
+  let(:reserved)      { "urn:example:/#?" }
+  let(:escaped_upper) { "urn:example:%25foo%2Fbar%3F%23" }
+  let(:escaped_lower) { "urn:example:%25foo%2fbar%3f%23" }
+  let(:only_escaped)  { "urn:example:%00" }
+  let(:long_nid)      { "urn:example-example-example-example-:foo" }
+
+  # Invalid URNs
+  let(:bad_prefix)     { "URN:example:foo" }
+  let(:empty_nid)      { "urn::foo" }
+  let(:leading_hyphen) { "urn:-example:foo" }
+  let(:bad_nid)        { "urn:example.com:foo" }
+  let(:percent_nid)    { "urn:example%41com:foo" }
+  let(:too_long_nid)   { "urn:example-example-example-example-x:foo" }
+  let(:empty_nss)      { "urn:example:" }
+  let(:naked_percent)  { "urn:example:%" }
+  let(:short_percent)  { "urn:example:%a" }
+  let(:nonhex_percent) { "urn:example:%ax" }
+
+  context "when testing a valid URN" do
+    it "should match a simple URN" do
+      expect(grok_match(pattern, simple)).to pass
+    end
+
+    it "should match a complex URN" do
+      expect(grok_match(pattern, unreserved)).to pass
+    end
+
+    it "should allow reserved characters" do
+      expect(grok_match(pattern, reserved)).to pass
+    end
+
+    it "should allow percent-escapes" do
+      expect(grok_match(pattern, escaped_upper)).to pass
+      expect(grok_match(pattern, escaped_lower)).to pass
+      expect(grok_match(pattern, only_escaped)).to pass
+    end
+
+    it "should match a URN with a 32-character NID" do
+      expect(grok_match(pattern, long_nid)).to pass
+    end
+  end
+
+  context "when testing an invalid URN" do
+    it "should reject capitalized 'URN'" do
+      expect(grok_match(pattern, bad_prefix)).not_to pass
+    end
+
+    it "should reject an empty NID" do
+      expect(grok_match(pattern, empty_nid)).not_to pass
+    end
+
+    it "should reject an NID with a leading hyphen" do
+      expect(grok_match(pattern, leading_hyphen)).not_to pass
+    end
+
+    it "should reject an NID with a special character" do
+      expect(grok_match(pattern, bad_nid)).not_to pass
+    end
+
+    it "should reject an NID with a percent sign" do
+      expect(grok_match(pattern, percent_nid)).not_to pass
+    end
+
+    it "should reject an NID longer than 32 characters" do
+      expect(grok_match(pattern, too_long_nid)).not_to pass
+    end
+
+    it "should reject a URN with an empty NSS" do
+      expect(grok_match(pattern, empty_nss)).not_to pass
+    end
+
+    it "should reject non-escape percent signs" do
+      expect(grok_match(pattern, naked_percent)).not_to pass
+      expect(grok_match(pattern, short_percent)).not_to pass
+      expect(grok_match(pattern, nonhex_percent)).not_to pass
+    end
+  end
 end


### PR DESCRIPTION
Note that [logstash-plugins/logstash-filter-grok](https://github.com/logstash-plugins/logstash-filter-grok) has not yet released a version including [`1cdbec4e`](https://github.com/logstash-plugins/logstash-filter-grok/commit/1cdbec4e309b2cbc5f2d6e0043af8320a7eb16c0), so testing this PR requires manually inserting its change.