### PR TITLE
Pattern for bind9

### DIFF
--- a/patterns/bind
+++ b/patterns/bind
@@ -1,0 +1,3 @@
+BIND9_TIMESTAMP %{MONTHDAY}[-]%{MONTH}[-]%{YEAR} %{TIME}
+
+BIND9 %{BIND9_TIMESTAMP:timestamp} queries: %{LOGLEVEL:loglevel}: client %{IP:clientip}#%{POSINT:clientport} \(%{GREEDYDATA:query}\): query: %{GREEDYDATA:query} IN %{GREEDYDATA:querytype} \(%{IP:dns}\)


### PR DESCRIPTION
Pattern for bind9. Log example:

```
11-Apr-2016 14:07:59.468 queries: info: client 192.168.1.3#36815 (stat.ripe.net): query: stat.ripe.net IN A + (8.8.8.8)
```