### PR TITLE
Update grok-patterns : WINPATH

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -35,7 +35,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 PATH (?:%{UNIXPATH}|%{WINPATH})
 UNIXPATH (/([\w_%!$@:.,~-]+|\\.)*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
-WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
+WINPATH (?>[A-Za-z]+:|\\|\/)(?:(\\|\/)[^(\\|\/)?*]*)+
 URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?
 URIHOST %{IPORHOST}(?::%{POSINT:port})?
 # uripath comes loosely from RFC1738, but mostly from what Firefox


### PR DESCRIPTION
Take into account windows paths with simple SLASH (/) characters.