### PR TITLE
accept '+' as a valid symbol in unix path

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -35,7 +35,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (/([\w_%!$@:.,~-]+|\\.)*)+
+UNIXPATH (/([\w_%!$@:.,+~-]+|\\.)*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?


### PR DESCRIPTION


Fixes: #153
Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>