### PR TITLE
Fix for unixpath endless backtracking problem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+  - Fix bug https://github.com/logstash-plugins/logstash-patterns-core/issues/159 with the introduction of atomic grouping (http://ruby-doc.org/core-2.3.0/Regexp.html#class-Regexp-label-Atomic+Grouping) for the unix path expression, this makes hte engine not to backtrack until timeout without specific reason, so expression gets optimized to find exit condition in such situations.
+
 ## 4.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/logstash-patterns-core.gemspec
+++ b/logstash-patterns-core.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-patterns-core'
-  s.version         = '4.0.2'
+  s.version         = '4.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Patterns to be used in logstash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -35,7 +35,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (/([\w_%!$@:.,+~-]+|\\.)*)+
+UNIXPATH (?>\/[[\w_%!$@:.,-]+|\\.]*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -111,6 +111,16 @@ describe "UNIXPATH" do
       expect(grok_match(pattern,value)).to pass
     end
   end
+
+  context "when using recursive paths" do
+
+    let(:pattern) { "%{UNIXPATH}/bar/%{DATA:fileName}" }
+    let(:value)   { "/foo/bar/my_input_file_12345.xml" }
+
+    it "should match the path expression" do
+      expect(grok_complex_match(pattern,value)).to pass
+    end
+  end
 end
 
 describe "URIPATH" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,14 +25,21 @@ require "logstash/filters/grok"
 
 module GrokHelpers
   def grok_match(label, message)
-    grok  = build_grok(label)
+    grok  = build_grok("%{#{label}}")
     event = build_event(message)
     grok.filter(event)
     event.to_hash
   end
 
-  def build_grok(label)
-    grok = LogStash::Filters::Grok.new("match" => ["message", "%{#{label}}"])
+  def grok_complex_match(expression, message)
+    grok  = build_grok(expression)
+    event = build_event(message)
+    grok.filter(event)
+    event.to_hash
+  end
+
+  def build_grok(expression)
+    grok = LogStash::Filters::Grok.new("match" => ["message", expression])
     grok.register
     grok
   end
@@ -54,7 +61,7 @@ end
 
 RSpec::Matchers.define :match do |value|
   match do |grok|
-    grok  = build_grok(grok)
+    grok  = build_grok("%{#{grok}}")
     event = build_event(value)
     grok.filter(event)
     !event.include?("tags")


### PR DESCRIPTION
Fixes bug #159 related to unix path backtracking until timeout due to not having proper finish condition. This commit add an atomic grouping for the unix path expression, so the path is required to match see http://ruby-doc.org/core-2.3.0/Regexp.html#class-Regexp-label-Atomic+Grouping
for more details.

Details around the issue could be found at #159.
