### PR TITLE
Add patterns for Barracuda Spam Firewall

### DIFF
--- a/patterns/bsf
+++ b/patterns/bsf
@@ -1,0 +1,13 @@
+# Barracuda Spam Firewall Grok Patterns
+# Fields: action_id, client_ip, client_name, destination, delivery_detail, encryption, message_id, process, reason_extra, reason_id, recipient, score, sender, service, message_size, subject, unix_start_time, unix_end_time
+
+BSF_SERVICE RECV|SCAN|SEND
+
+# Common Particles
+BSF_SCAN %{NOTSPACE:process}: %{NOTSPACE:client_name}\[%{IP:client_ip}\] %{NOTSPACE:message_id} %{NOTSPACE:unix_start_time} %{NOTSPACE:unix_end_time} %{BSF_SERVICE:service} %{NOTSPACE:encryption} %{NOTSPACE:sender} %{NOTSPACE:recipient} %{NOTSPACE:score} %{NOTSPACE:action_id} %{NOTSPACE:reason_id} %{GREEDYDATA:reason_extra} SZ:%{NOTSPACE:message_size} SUBJ:%{GREEDYDATA:subject}
+BSF_SEND %{NOTSPACE:process}: %{IP:client_ip} %{NOTSPACE:message_id} %{NOTSPACE:unix_start_time} %{NOTSPACE:unix_end_time} %{BSF_SERVICE:service} %{NOTSPACE:encryption} %{NOTSPACE:action_id} %{NOTSPACE:queue_id} %{GREEDYDATA:delivery_detail} #to#%{GREEDYDATA:destination}
+BSF_SEND_NO_DESTINATION %{NOTSPACE:process}: %{IP:client_ip} %{NOTSPACE:message_id} %{NOTSPACE:unix_start_time} %{NOTSPACE:unix_end_time} %{BSF_SERVICE:service} %{NOTSPACE:encryption} %{NOTSPACE:action_id} %{NOTSPACE:queue_id} %{GREEDYDATA:delivery_detail}
+BSF_RECV_SCAN %{NOTSPACE:process}: %{NOTSPACE:client_name}\[%{IP:client_ip}\] %{NOTSPACE:message_id} %{NOTSPACE:unix_start_time} %{NOTSPACE:unix_end_time} %{BSF_SERVICE:service} %{NOTSPACE:encryption} %{NOTSPACE:sender} %{NOTSPACE:recipient} %{NOTSPACE:score} %{NOTSPACE:action_id} %{NOTSPACE:reason_id} %{GREEDYDATA:reason_extra} SZ:%{NOTSPACE:message_size} SUBJ:%{GREEDYDATA:subject}
+BSF_RECV_SCAN_2 %{NOTSPACE:process}: \[%{IP:client_ip}\] %{NOTSPACE:message_id} %{NOTSPACE:unix_start_time} %{NOTSPACE:unix_end_time} %{BSF_SERVICE:service} %{NOTSPACE:encryption} %{NOTSPACE:sender} %{NOTSPACE:recipient} %{NOTSPACE:score} %{NOTSPACE:action_id} %{NOTSPACE:reason_id} %{GREEDYDATA:reason_extra} SZ:%{NOTSPACE:message_size} SUBJ:%{GREEDYDATA:subject}
+BSF_RECV %{NOTSPACE:process}: %{NOTSPACE:client_name}\[%{IP:client_ip}\] %{NOTSPACE:message_id} %{NOTSPACE:unix_start_time} %{NOTSPACE:unix_end_time} %{BSF_SERVICE:service} %{NOTSPACE:sender} %{NOTSPACE:recipient} %{NOTSPACE:action_id} %{NOTSPACE:reason_id} %{GREEDYDATA:reason_extra}
+BSF_WEB_SYSLOG %{GREEDYDATA:message}


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

- Parse 4 types of BSF processes: scan, send, inbound/pass1,
inbound/pass2
- Work properly on BSF firmware v7.x.x.xxx and recent versions.