### PR TITLE
Minor improvement to S3 grok patterns

### DIFF
--- a/patterns/aws
+++ b/patterns/aws
@@ -1,6 +1,6 @@
 S3_REQUEST_LINE (?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
 
-S3_ACCESS_LOG %{WORD:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) (?:%{INT:response:int}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) (?:%{QS:referrer}|-) (?:"?%{QS:agent}"?|-) (?:-|%{NOTSPACE:version_id})
+S3_ACCESS_LOG %{WORD:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} (?:-|%{NOTSPACE:requester}) %{NOTSPACE:request_id} %{NOTSPACE:operation} (?:-|%{NOTSPACE:key}) (?:"%{S3_REQUEST_LINE}"|-) (?:%{INT:response:int}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) (?:%{QS:referrer}|-) (?:"?%{QS:agent}"?|-) (?:-|%{NOTSPACE:version_id})
 
 ELB_URIPATHPARAM %{URIPATH:path}(?:%{URIPARAM:params})?
 

--- a/spec/patterns/s3_spec.rb
+++ b/spec/patterns/s3_spec.rb
@@ -75,7 +75,7 @@ describe "S3_ACCESS_LOG" do
     it { should include("requester" => "79a5" ) }
     it { should include("request_id" => "3E57427F3EXAMPLE" ) }
     it { should include("operation" => "REST.GET.VERSIONING" ) }
-    it { should include("key" => "-" ) }
+    it { should_not include("key") }
 
     it { should include("verb" => "GET" ) }
     it { should include("request" => "/mybucket?versioning" ) }
@@ -106,7 +106,7 @@ describe "S3_ACCESS_LOG" do
     it { should include("bucket" => "mybucket" ) }
     it { should include("timestamp" => "12/May/2014:07:54:01 +0000" ) }
     it { should include("clientip" => "10.0.1.2" ) }
-    it { should include("requester" => "-" ) }
+    it { should_not include("requester") }
     it { should include("request_id" => "7ACC4BE89EXAMPLE" ) }
     it { should include("operation" => "REST.GET.OBJECT" ) }
     it { should include("key" => "foo/bar.html" ) }


### PR DESCRIPTION
Allows for the `requester` and `key` fields to be `-`, which is equivalent to `null`.