### PR TITLE
Make the S3 parsing more strict

### DIFF
--- a/patterns/aws
+++ b/patterns/aws
@@ -1,6 +1,6 @@
 S3_REQUEST_LINE (?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})
 
-S3_ACCESS_LOG %{WORD:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{NOTSPACE:requester} %{NOTSPACE:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} (?:"%{S3_REQUEST_LINE}"|-) (?:%{INT:response:int}|-) (?:-|%{NOTSPACE:error_code}) (?:%{INT:bytes:int}|-) (?:%{INT:object_size:int}|-) (?:%{INT:request_time_ms:int}|-) (?:%{INT:turnaround_time_ms:int}|-) (?:%{QS:referrer}|-) (?:"?%{QS:agent}"?|-) (?:-|%{NOTSPACE:version_id})
+S3_ACCESS_LOG %{BASE16NUM:owner} %{NOTSPACE:bucket} \[%{HTTPDATE:timestamp}\] %{IP:clientip} %{BASE16NUM:requester} %{WORD:request_id} %{NOTSPACE:operation} %{NOTSPACE:key} "%{S3_REQUEST_LINE}" (?:%{POSINT:response:int}|-) (?:-|%{WORD:error_code}) (?:%{NONNEGINT:bytes:int}|-) (?:%{NONNEGINT:object_size:int}|-) (?:%{NONNEGINT:request_time_ms:int}|-) (?:%{NONNEGINT:turnaround_time_ms:int}|-) (?:%{QS:referrer}|-) (?:%{QS:agent}|-) (?:-|%{WORD:version_id})
 
 ELB_URIPATHPARAM %{URIPATH:path}(?:%{URIPARAM:params})?
 


### PR DESCRIPTION
Tightens up some patterns for stricter matching:

  - Changed `%{WORD:owner}` to `%{BASE16NUM:owner}`.
  - Changed `%{NOTSPACE:request_id}` to `%{BASE16NUM:request_id}`.
  - Changed `%{INT:response}` to `%{POSINT:response}`.
  - Changed `%{NOTSPACE:error_code}` to `%{WORD:error_code}`.
  - Changed `%{INT:bytes}` to `%{NONNEGINT:bytes}`.
  - Changed `%{INT:object_size}` to `%{NONNEGINT:object_size}`.
  - Changed `%{INT:request_time_ms}` to `%{NONNEGINT:request_time_ms}`.
  - Remove unnecessary double quotes from the agent field.
  - Changed `%{NOTSPACE:version_id}` to `%{WORD:version_id}`.