### PR TITLE
Update URIPROTO to match RFC3986

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,6 +36,7 @@ Contributors:
 * Matthew Baxa (mbaxa)
 * MikeSchuette
 * Nick Padilla (NickPadilla)
+* Olaf van Zandwijk (olafz)
 * Oluf Lorenzen (Finkregh)
 * Paul Myjavec (pmyjavec)
 * Pete Fritchman (fetep)

--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -37,7 +37,7 @@ PATH (?:%{UNIXPATH}|%{WINPATH})
 UNIXPATH (/([\w_%!$@:.,+~-]+|\\.)*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
-URIPROTO [A-Za-z]+(\+[A-Za-z+]+)?
+URIPROTO [A-Za-z]([A-Za-z0-9+\-.]+)+
 URIHOST %{IPORHOST}(?::%{POSINT:port})?
 # uripath comes loosely from RFC1738, but mostly from what Firefox
 # doesn't turn into %XX

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -103,6 +103,26 @@ describe "UNIXPATH" do
   end
 end
 
+describe "URIPROTO" do
+  let(:pattern) { 'URIPROTO' }
+
+  context "http is a valid URIPROTO" do
+    let(:value) { 'http' }
+
+    it "should match" do
+      expect(grok_match(pattern,value)).to pass
+    end
+  end
+
+  context "android-app is a valid URIPROTO" do
+    let(:value) { 'android-app' }
+
+    it "should match" do
+      expect(grok_match(pattern,value)).to pass
+    end
+  end
+end
+
 describe "URIPATH" do
   let(:pattern) { 'URIPATH' }
 


### PR DESCRIPTION
According to RFC 3986 (paragraph 3.1):
> Scheme names consist of a sequence of characters beginning with a letter and followed by any combination of letters, digits, plus ("+"), period ("."), or hyphen ("-").

What is called a scheme in the RFC, is referred to as `URIPROTO` in Logstash patterns. For instance, a valid URI would be "android-app://...", but is currently not captured by the Grok pattern for URI. This PR fixes that.