### PR TITLE
Add patterns for some message IDs

### DIFF
--- a/patterns/firewalls
+++ b/patterns/firewalls
@@ -84,6 +84,8 @@ CISCOFW713172 Group = %{GREEDYDATA:group}, IP = %{IP:src_ip}, Automatic NAT Dete
 CISCOFW713202 %{CISCO_MESSAGE_ID:message_id}: IP = %{IP:src_ip}, %{GREEDYDATA:reason}. %{CISCO_ACTION:action} packet.
 # ASA-4-733100
 CISCOFW733100 \[\s*%{DATA:drop_type}\s*\] drop %{DATA:drop_rate_id} exceeded. Current burst rate is %{INT:drop_rate_current_burst} per second, max configured rate is %{INT:drop_rate_max_burst}; Current average rate is %{INT:drop_rate_current_avg} per second, max configured rate is %{INT:drop_rate_max_avg}; Cumulative total count is %{INT:drop_total_count}
+# ASA-5-750006
+CISCOFW750006 %{CISCO_MESSAGE_ID:message_id}: Local:%{IP:dst_ip}:%{INT:dst_port} Remote:%{IP:src_ip}:%{INT:src_port} Username:%{USERNAME:username} %{DATA}. Reason: %{CISCO_REASON:reason}
 #== End Cisco ASA ==
 
 # Shorewall firewall logs

--- a/patterns/firewalls
+++ b/patterns/firewalls
@@ -5,8 +5,9 @@ NETSCREENSESSIONLOG %{SYSLOGTIMESTAMP:date} %{IPORHOST:device} %{IPORHOST}: NetS
 CISCO_TAGGED_SYSLOG ^<%{POSINT:syslog_pri}>%{CISCOTIMESTAMP:timestamp}( %{SYSLOGHOST:sysloghost})? ?: %%{CISCOTAG:ciscotag}:
 CISCOTIMESTAMP %{MONTH} +%{MONTHDAY}(?: %{YEAR})? %{TIME}
 CISCOTAG [A-Z0-9]+-%{INT}-(?:[A-Z0-9_]+)
+CISCO_MESSAGE_ID \d{6}
 # Common Particles
-CISCO_ACTION Built|Teardown|Deny|Denied|denied|requested|permitted|denied by ACL|discarded|est-allowed|Dropping|created|deleted
+CISCO_ACTION Built|Teardown|Deny|Denied|denied|requested|permitted|denied by ACL|discarded|est-allowed|Dropping|created|deleted|Ignoring
 CISCO_REASON Duplicate TCP SYN|Failed to locate egress interface|Invalid transport field|No matching connection|DNS Response|DNS Query|(?:%{WORD}\s*)*
 CISCO_DIRECTION Inbound|inbound|Outbound|outbound
 CISCO_INTERVAL first hit|%{INT}-second interval
@@ -79,6 +80,8 @@ CISCOFW602303_602304 %{WORD:protocol}: An %{CISCO_DIRECTION:direction} %{GREEDYD
 CISCOFW710001_710002_710003_710005_710006 %{WORD:protocol} (?:request|access) %{CISCO_ACTION:action} from %{IP:src_ip}/%{INT:src_port} to %{DATA:dst_interface}:%{IP:dst_ip}/%{INT:dst_port}
 # ASA-6-713172
 CISCOFW713172 Group = %{GREEDYDATA:group}, IP = %{IP:src_ip}, Automatic NAT Detection Status:\s+Remote end\s*%{DATA:is_remote_natted}\s*behind a NAT device\s+This\s+end\s*%{DATA:is_local_natted}\s*behind a NAT device
+# ASA-5-713202
+CISCOFW713202 %{CISCO_MESSAGE_ID:message_id}: IP = %{IP:src_ip}, %{GREEDYDATA:reason}. %{CISCO_ACTION:action} packet.
 # ASA-4-733100
 CISCOFW733100 \[\s*%{DATA:drop_type}\s*\] drop %{DATA:drop_rate_id} exceeded. Current burst rate is %{INT:drop_rate_current_burst} per second, max configured rate is %{INT:drop_rate_max_burst}; Current average rate is %{INT:drop_rate_current_avg} per second, max configured rate is %{INT:drop_rate_max_avg}; Cumulative total count is %{INT:drop_total_count}
 #== End Cisco ASA ==

--- a/patterns/firewalls
+++ b/patterns/firewalls
@@ -50,6 +50,8 @@ CISCOFW106100 access-list %{NOTSPACE:policy_id} %{CISCO_ACTION:action} %{WORD:pr
 CISCOFW304001 %{IP:src_ip}(\(%{DATA:src_fwuser}\))? Accessed URL %{IP:dst_ip}:%{GREEDYDATA:dst_url}
 # ASA-6-110002
 CISCOFW110002 %{CISCO_REASON:reason} for %{WORD:protocol} from %{DATA:src_interface}:%{IP:src_ip}/%{INT:src_port} to %{IP:dst_ip}/%{INT:dst_port}
+# ASA-6-113009
+CISCOFW113009 %{CISCO_MESSAGE_ID:message_id}: %{CISCO_REASON:reason} \(%{WORD:src_name}\) for user = %{USERNAME:username}
 # ASA-6-302010
 CISCOFW302010 %{INT:connection_count} in use, %{INT:connection_count_max} most used
 # ASA-6-302013, ASA-6-302014, ASA-6-302015, ASA-6-302016

--- a/patterns/firewalls
+++ b/patterns/firewalls
@@ -64,6 +64,8 @@ CISCOFW313001_313004_313008 %{CISCO_ACTION:action} %{WORD:protocol} type=%{INT:i
 CISCOFW313005 %{CISCO_REASON:reason} for %{WORD:protocol} error message: %{WORD:err_protocol} src %{DATA:err_src_interface}:%{IP:err_src_ip}(\(%{DATA:err_src_fwuser}\))? dst %{DATA:err_dst_interface}:%{IP:err_dst_ip}(\(%{DATA:err_dst_fwuser}\))? \(type %{INT:err_icmp_type}, code %{INT:err_icmp_code}\) on %{DATA:interface} interface\.  Original IP payload: %{WORD:protocol} src %{IP:orig_src_ip}/%{INT:orig_src_port}(\(%{DATA:orig_src_fwuser}\))? dst %{IP:orig_dst_ip}/%{INT:orig_dst_port}(\(%{DATA:orig_dst_fwuser}\))?
 # ASA-5-321001
 CISCOFW321001 Resource '%{WORD:resource_name}' limit of %{POSINT:resource_limit} reached for system
+# ASA-4-402116
+CISCOFW402116 %{WORD:protocol}: Received an %{WORD:orig_protocol} packet \(SPI= %{DATA:spi}, sequence number= %{DATA:seq_num}\) from %{IP:src_ip} \(user= %{USERNAME:username}\) to %{IP:dst_ip}
 # ASA-4-402117
 CISCOFW402117 %{WORD:protocol}: Received a non-IPSec packet \(protocol= %{WORD:orig_protocol}\) from %{IP:src_ip} to %{IP:dst_ip}
 # ASA-4-402119

--- a/patterns/firewalls
+++ b/patterns/firewalls
@@ -80,6 +80,8 @@ CISCOFW419002 %{CISCO_REASON:reason} from %{DATA:src_interface}:%{IP:src_ip}/%{I
 CISCOFW500004 %{CISCO_REASON:reason} for protocol=%{WORD:protocol}, from %{IP:src_ip}/%{INT:src_port} to %{IP:dst_ip}/%{INT:dst_port}
 # ASA-6-602303, ASA-6-602304
 CISCOFW602303_602304 %{WORD:protocol}: An %{CISCO_DIRECTION:direction} %{GREEDYDATA:tunnel_type} SA \(SPI= %{DATA:spi}\) between %{IP:src_ip} and %{IP:dst_ip} \(user= %{DATA:user}\) has been %{CISCO_ACTION:action}
+# ASA-6-605005
+CISCOFW605005 %{CISCO_MESSAGE_ID:message_id}: %{CISCO_REASON:reason} from %{IP:src_ip}\/%{INT:src_port} to %{DATA:dst_interface}:%{IP:dst_ip}\/%{DATA:service} for user "%{USERNAME:username}"
 # ASA-7-710001, ASA-7-710002, ASA-7-710003, ASA-7-710005, ASA-7-710006
 CISCOFW710001_710002_710003_710005_710006 %{WORD:protocol} (?:request|access) %{CISCO_ACTION:action} from %{IP:src_ip}/%{INT:src_port} to %{DATA:dst_interface}:%{IP:dst_ip}/%{INT:dst_port}
 # ASA-6-713172


### PR DESCRIPTION
- Add patterns for some message IDs
- Add a pattern for message IDs and assign the value to field `message_id`. Having `message_id` field  allows us to group events together, and we can also use dictionary filter plugin to add Cisco [recommended action](http://www.cisco.com/c/en/us/td/docs/security/asa/syslog-guide/syslogs.html) based on this field.

If possible, I also want to update existing Cisco patterns to extract this `message_id` field. Cisco syslog is quite helpful for me to troubleshoot network issues.