### PR TITLE
adding a log format pattern for glassfish4/payara application servers

### DIFF
--- a/patterns/java
+++ b/patterns/java
@@ -17,3 +17,4 @@ TOMCAT_DATESTAMP 20%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:?%{MINUTE}(?::?%{SECO
 CATALINALOG %{CATALINA_DATESTAMP:timestamp} %{JAVACLASS:class} %{JAVALOGMESSAGE:logmessage}
 # 2014-01-09 20:03:28,269 -0800 | ERROR | com.example.service.ExampleService - something compeletely unexpected happened...
 TOMCATLOG %{TOMCAT_DATESTAMP:timestamp} \| %{LOGLEVEL:level} \| %{JAVACLASS:class} - %{JAVALOGMESSAGE:logmessage}
+GLASSFISHLOG \[%{TIMESTAMP_ISO8601:timestamp}\] \[%{DATA:product_name}\] \[%{WORD:severity}\] \[%{DATA:message_id}\] \[%{DATA:logger}\] \[tid: %{DATA:thread}\] \[timeMillis: %{NONNEGINT:time_millis}\] \[levelValue: %{NONNEGINT:level_value}\] \[\[\n  %{GREEDYDATA:payload}\]\]


### PR DESCRIPTION
Default log format for the application servers glassfish 4 and payara (which is deriveed from glassfish). Here is an example log line:

    [2017-05-15T11:45:13.506+0200] [Payara 4.1] [INFO] [] [de.tln.aexit.pp.scratch.service.HealthCheckService] [tid: _ThreadID=100 _ThreadName=http-thread-pool::http-listener-1(1)] [timeMillis: 1494841513506] [levelValue: 800] [[
      status api request -- info]]