### PR TITLE
Process hits messages

### DIFF
--- a/patterns/squid
+++ b/patterns/squid
@@ -1,4 +1,4 @@
 # Pattern squid3
 # Documentation of squid3 logs formats can be found at the following link:
 # http://wiki.squid-cache.org/Features/LogFormat
-SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:duration}\s%{IP:client_address}\s%{WORD:cache_result}/%{POSINT:status_code}\s%{NUMBER:bytes}\s%{WORD:request_method}\s%{NOTSPACE:url}\s(%{NOTSPACE:user}|-)\s%{WORD:hierarchy_code}/%{IPORHOST:server}\s%{NOTSPACE:content_type}
+SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:duration}\s%{IP:client_address}\s%{WORD:cache_result}/%{POSINT:status_code}\s%{NUMBER:bytes}\s%{WORD:request_method}\s%{NOTSPACE:url}\s(%{NOTSPACE:user}|-)\s%{WORD:hierarchy_code}/(%{IPORHOST:server}|-)\s%{NOTSPACE:content_type}


### PR DESCRIPTION
The SQUID3 pattern doesn't match HIT messages because they have a dash instead of a IPORHOST.

i.e. this is a MISS:
```1521833853.707 11 10.0.1.14 TCP_MISS/204 198 GET http://clients3.google.com/generate_204 - ORIGINAL_DST/172.217.0.238 -```
and this is a HIT:
```1521831980.154 19 10.0.1.25 TCP_MEM_HIT/200 153452 GET http://example.com/img.jpg - HIER_NONE/- image/jpeg```

The pattern in its current form expects an IPORHOST after the `/` here: `HIER_NONE/-`. This PR changes the expectation to IPORHOST or `-` so it can process HITs correctly.