### PR TITLE
local part for email address can start with numbers

### DIFF
--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -1,6 +1,6 @@
 USERNAME [a-zA-Z0-9._-]+
 USER %{USERNAME}
-EMAILLOCALPART [a-zA-Z][a-zA-Z0-9_.+-=:]+
+EMAILLOCALPART [a-zA-Z0-9][a-zA-Z0-9_.+-=:]+
 EMAILADDRESS %{EMAILLOCALPART}@%{HOSTNAME}
 INT (?:[+-]?(?:[0-9]+))
 BASE10NUM (?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+)))


### PR DESCRIPTION
Local part for email addresses can start with numbers: https://en.wikipedia.org/wiki/Email_address

It can actually contain any combination but realistically, it be an alphanumeric character.
