### PR TITLE
Introducing alb logs pattern

### DIFF
--- a/patterns/aws
+++ b/patterns/aws
@@ -12,3 +12,4 @@ ELB_ACCESS_LOG %{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:elb} %{IP:clientip}:%{I
 
 CLOUDFRONT_ACCESS_LOG (?<timestamp>%{YEAR}-%{MONTHNUM}-%{MONTHDAY}\t%{TIME})\t%{WORD:x_edge_location}\t(?:%{NUMBER:sc_bytes:int}|-)\t%{IPORHOST:clientip}\t%{WORD:cs_method}\t%{HOSTNAME:cs_host}\t%{NOTSPACE:cs_uri_stem}\t%{NUMBER:sc_status:int}\t%{GREEDYDATA:referrer}\t%{GREEDYDATA:agent}\t%{GREEDYDATA:cs_uri_query}\t%{GREEDYDATA:cookies}\t%{WORD:x_edge_result_type}\t%{NOTSPACE:x_edge_request_id}\t%{HOSTNAME:x_host_header}\t%{URIPROTO:cs_protocol}\t%{INT:cs_bytes:int}\t%{GREEDYDATA:time_taken:float}\t%{GREEDYDATA:x_forwarded_for}\t%{GREEDYDATA:ssl_protocol}\t%{GREEDYDATA:ssl_cipher}\t%{GREEDYDATA:x_edge_response_result_type}
 
+ALB_ACCESS_LOG %{DATA:request_type} %{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:alb_reso


### PR DESCRIPTION
 We have been using this in our production systems and is working fine. Adding this since there is no formatter dedicated to ALB access logs.

Have tested this against below inputs

```
http 2020-04-09T23:50:47.074072Z app/OJProdLoadBalancer/278a3c7472bb5054 63.143.42.245:35290 - -1 -1 -1 301 - 429 206 "HEAD http://abc.com:80/packages HTTP/1.1" "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)" - - - "Root=1-5e8fb4d6-88f9ba6fa59e2a9b5ce6a282" "-" "-" 0 2020-04-09T23:50:46.843000Z "redirect" "https://abc.com:443/packages" "-" "-" "-"

https 2020-04-09T23:51:41.309191Z app/OJProdLoadBalancer/278a3c7472bb5054 63.143.42.244:23863 172.31.2.30:5001 0.002 0.217 0.000 200 200 448 348 "HEAD https://abc.com:443/packages/maldives HTTP/1.1" "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:ap-south-1:855430014109:targetgroup/ABC-FrontEnd/8c8983a24851ee4a "Root=1-5e8fb50d-df9a95404831631626fb545e" "abc.com" "arn:aws:acm:ap-south-1:855430014109:certificate/e3fb2074-0c09-4be9-a32c-5c985e540144" 0 2020-04-09T23:51:41.090000Z "forward" "-" "-" "172.31.2.30:5001" "200"

https 2020-04-09T23:52:26.407761Z app/OJProdLoadBalancer/278a3c7472bb5054 63.143.42.243:19373 192.168.2.2:5001 0.001 0.090 0.000 200 200 413 347 "HEAD https://abc.com:443/ HTTP/1.1" "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:ap-south-1:855430014109:targetgroup/ABC-FrontEnd/8c8983a24851ee4a "Root=1-5e8fb53a-6b9458dd885ba264cd24e6f6" "abc.com" "arn:aws:acm:ap-south-1:855430014109:certificate/e3fb2074-0c09-4be9-a32c-5c985e540144" 0 2020-04-09T23:52:26.316000Z "forward" "-" "-" "192.168.2.2:5001" "200"

https 2020-04-09T23:53:48.683057Z app/OJProdLoadBalancer/278a3c7472bb5054 63.143.42.248:21364 192.168.2.2:5001 0.001 0.089 0.000 200 200 413 347 "HEAD https://abc.com:443/ HTTP/1.1" "Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:ap-south-1:855430014109:targetgroup/ABC-FrontEnd/8c8983a24851ee4a "Root=1-5e8fb58c-b97858eefa7acb88b92f4ebe" "abc.com" "arn:aws:acm:ap-south-1:855430014109:certificate/e3fb2074-0c09-4be9-a32c-5c985e540144" 0 2020-04-09T23:53:48.593000Z "forward" "-" "-" "192.168.2.2:5001" "200"
```