### PR TITLE
add HAPROXYERROR pattern to parse error lines.

### DIFF
--- a/patterns/haproxy
+++ b/patterns/haproxy
@@ -37,3 +37,6 @@ HAPROXYHTTP (?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:timestamp
 
 # parse a haproxy 'tcplog' line
 HAPROXYTCP (?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:timestamp8601}) %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{IP:client_ip}:%{INT:client_port} \[%{HAPROXYDATE:accept_date}\] %{NOTSPACE:frontend_name} %{NOTSPACE:backend_name}/%{NOTSPACE:server_name} %{INT:time_queue}/%{INT:time_backend_connect}/%{NOTSPACE:time_duration} %{NOTSPACE:bytes_read} %{NOTSPACE:termination_state} %{INT:actconn}/%{INT:feconn}/%{INT:beconn}/%{INT:srvconn}/%{NOTSPACE:retries} %{INT:srv_queue}/%{INT:backend_queue}
+
+# parse a haproxy 'error' line
+HAPROXYERROR (?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:timestamp8601}) %{IPORHOST:syslog_server} %{SYSLOGPROG}: %{IP:client_ip}:%{INT:client_port} \[%{HAPROXYDATE:accept_date}\] %{NOTSPACE:frontend_name}/%{NOTSPACE:bind_name}: %{GREEDYDATA:error_message}


### PR DESCRIPTION
Add the pattern to parse the 'error' lines from HAProxy logs.

From the [documentation](https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#8.2.5), besides the default **http** log line and **tcp** log line, you can also have an **error** log line with the following format.

> Error log format
When an incoming connection fails due to an SSL handshake or an invalid PROXY
protocol header, haproxy will log the event using a shorter, fixed line format.

> Dec  3 18:27:14 localhost  haproxy[6103]: 127.0.0.1:56059 [03/Dec/2012:17:35:10.380] frt/f1:  Connection error during SSL handshake

This error line has the following fields.
```
Field   Format                                Extract from the example above
      1   process_name '[' pid ']:'                             haproxy[6103]:
      2   client_ip ':' client_port                            127.0.0.1:56059
      3   '[' accept_date ']'                       [03/Dec/2012:17:35:10.380]
      4   frontend_name "/" bind_name ":"                              frt/f1:
      5   message                        Connection error during SSL handshake
```

The pattern `%{HAPROXYERROR}` will parse the above line and create two new fields in the output event, `bind_name` and `error_message`, the original `message` field from the description above was changed to `error_message` to avoid conflict with the event `message` field.