### PR TITLE
Feat: redis patterns ecs compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,6 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
+
+# TODO till filter grok with ECS support is released :
+gem 'logstash-filter-grok', github: 'kares/logstash-filter-grok', ref: 'ecs-1-support'

--- a/lib/logstash/patterns/core.rb
+++ b/lib/logstash/patterns/core.rb
@@ -3,8 +3,16 @@ module LogStash
     module Core
       extend self
 
-      def path
-        ::File.expand_path('../../../patterns/legacy', ::File.dirname(__FILE__))
+      BASE_PATH = ::File.expand_path('../../../patterns', ::File.dirname(__FILE__))
+      private_constant :BASE_PATH
+
+      def path(type = :legacy)
+        case type = type.to_s
+        when 'legacy', 'ecs-v1'
+          ::File.join(BASE_PATH, type)
+        else
+          raise ArgumentError, "#{type.inspect} path not supported"
+        end
       end
 
     end

--- a/patterns/ecs-v1/redis
+++ b/patterns/ecs-v1/redis
@@ -1,3 +1,3 @@
 REDISTIMESTAMP %{MONTHDAY} %{MONTH} %{TIME}
-REDISLOG \[%{POSINT:pid}\] %{REDISTIMESTAMP:timestamp} \* 
-REDISMONLOG %{NUMBER:timestamp} \[%{INT:database} %{IP:client}:%{NUMBER:port}\] "%{WORD:command}"\s?%{GREEDYDATA:params}
+REDISLOG \[%{POSINT:[process][pid]:int}\] %{REDISTIMESTAMP:timestamp} \*
+REDISMONLOG %{NUMBER:timestamp} \[%{INT:[redis][database][id]} %{IP:[client][ip]}:%{POSINT:[client][port]:int}\] "%{WORD:[redis][command][name]}"\s?%{GREEDYDATA:[redis][command][args]}

--- a/spec/patterns/redis_spec.rb
+++ b/spec/patterns/redis_spec.rb
@@ -135,74 +135,74 @@ describe_pattern 'REDISMONLOG', [ 'legacy', 'ecs-v1' ] do
 
 end
 
-describe "REDISMONLOG (two param command)" do
+describe_pattern "REDISMONLOG" do
 
-  let(:pattern) { "REDISMONLOG" }
-  let(:message) { "1470637925.186681 [0 127.0.0.1:39404] \"rpush\" \"my:special:key\" \"{\\\"data\\\":\"cdr\\\",\\\"payload\\\":\\\"json\\\"}\"" }
-  let(:grok)    { grok_match(pattern, message) }
+  context 'two param command' do
 
-  it "a pattern pass the grok expression" do
-    expect(grok).to pass
+    let(:message) { "1470637925.186681 [0 127.0.0.1:39404] \"rpush\" \"my:special:key\" \"{\\\"data\\\":\"cdr\\\",\\\"payload\\\":\\\"json\\\"}\"" }
+
+    it "a pattern pass the grok expression" do
+      expect(grok).to pass
+    end
+
+    it "generates the timestamp field" do
+      expect(grok).to include("timestamp" => "1470637925.186681")
+    end
+
+    it "generates the database field" do
+      expect(grok).to include("database" => "0")
+    end
+
+    it "generates the client field" do
+      expect(grok).to include("client" => "127.0.0.1")
+    end
+
+    it "generates the port field" do
+      expect(grok).to include("port" => "39404")
+    end
+
+    it "generates the command field" do
+      expect(grok).to include("command" => "rpush")
+    end
+
+    it "generates the params field" do
+      expect(grok).to include("params" => "\"my:special:key\" \"{\\\"data\\\":\"cdr\\\",\\\"payload\\\":\\\"json\\\"}\"")
+    end
+
   end
 
-  it "generates the timestamp field" do
-    expect(grok).to include("timestamp" => "1470637925.186681")
-  end
+  context "variadic command" do
 
-  it "generates the database field" do
-    expect(grok).to include("database" => "0")
-  end
+    let(:message) { "1470637875.777457 [15 195.168.1.1:52500] \"intentionally\" \"broken\" \"variadic\" \"log\" \"entry\"" }
 
-  it "generates the client field" do
-    expect(grok).to include("client" => "127.0.0.1")
-  end
+    it "a pattern pass the grok expression" do
+      expect(grok).to pass
+    end
 
-  it "generates the port field" do
-    expect(grok).to include("port" => "39404")
-  end
+    it "generates the timestamp field" do
+      expect(grok).to include("timestamp" => "1470637875.777457")
+    end
 
-  it "generates the command field" do
-    expect(grok).to include("command" => "rpush")
-  end
+    it "generates the database field" do
+      expect(grok).to include("database" => "15")
+    end
 
-  it "generates the params field" do
-    expect(grok).to include("params" => "\"my:special:key\" \"{\\\"data\\\":\"cdr\\\",\\\"payload\\\":\\\"json\\\"}\"")
-  end
+    it "generates the client field" do
+      expect(grok).to include("client" => "195.168.1.1")
+    end
 
-end
+    it "generates the port field" do
+      expect(grok).to include("port" => "52500")
+    end
 
-describe "REDISMONLOG (variadic command)" do
+    it "generates the command field" do
+      expect(grok).to include("command" => "intentionally")
+    end
 
-  let(:pattern) { "REDISMONLOG" }
-  let(:message) { "1470637875.777457 [15 195.168.1.1:52500] \"intentionally\" \"broken\" \"variadic\" \"log\" \"entry\"" }
-  let(:grok)    { grok_match(pattern, message) }
+    it "generates the params field" do
+      expect(grok).to include("params" => "\"broken\" \"variadic\" \"log\" \"entry\"")
+    end
 
-  it "a pattern pass the grok expression" do
-    expect(grok).to pass
-  end
-
-  it "generates the timestamp field" do
-    expect(grok).to include("timestamp" => "1470637875.777457")
-  end
-
-  it "generates the database field" do
-    expect(grok).to include("database" => "15")
-  end
-
-  it "generates the client field" do
-    expect(grok).to include("client" => "195.168.1.1")
-  end
-
-  it "generates the port field" do
-    expect(grok).to include("port" => "52500")
-  end
-
-  it "generates the command field" do
-    expect(grok).to include("command" => "intentionally")
-  end
-
-  it "generates the params field" do
-    expect(grok).to include("params" => "\"broken\" \"variadic\" \"log\" \"entry\"")
   end
 
 end

--- a/spec/patterns/redis_spec.rb
+++ b/spec/patterns/redis_spec.rb
@@ -2,107 +2,144 @@
 require "spec_helper"
 require "logstash/patterns/core"
 
-describe "REDISTIMESTAMP" do
+describe_pattern 'REDISTIMESTAMP', [ 'legacy', 'ecs-v1' ] do
 
-  let(:value) { '14 Nov 07:01:22.119'}
-  let(:pattern) { "REDISTIMESTAMP" }
+  let(:message) { '14 Nov 07:01:22.119'}
 
   it "a pattern pass the grok expression" do
-    expect(grok_match(pattern, value)).to pass
+    expect(grok_match(pattern, message)).to pass
   end
 
 end
 
-describe "REDISLOG" do
+describe_pattern 'REDISLOG', [ 'legacy', 'ecs-v1' ] do
 
-  let(:value)   { "[4018] 14 Nov 07:01:22.119 * Background saving terminated with success" }
-  let(:pattern) { "REDISLOG" }
-  let(:grok)    { grok_match(pattern, value) }
+  let(:message) { "[4018] 14 Nov 07:01:22.119 * Background saving terminated with success" }
 
   it "a pattern pass the grok expression" do
     expect(grok).to pass
   end
 
   it "generates the pid field" do
-    expect(grok).to include("pid" => "4018")
+    puts "ecs_compatibility?: #{ecs_compatibility?.inspect}"
+    if ecs_compatibility?
+      expect(grok).to include("process" => { 'pid' => 4018 })
+    else
+      expect(grok).to include("pid" => "4018")
+    end
   end
 
 end
 
+describe_pattern 'REDISMONLOG', [ 'legacy', 'ecs-v1' ] do
 
-describe "REDISMONLOG - SIMPLE COMMAND" do
+  context "simple command" do
 
-  let(:value)   { "1470637867.953466 [0 195.168.1.1:52500] \"info\"" }
-  let(:pattern) { "REDISMONLOG" }
-  let(:grok)    { grok_match(pattern, value) }
+    let(:message) { "1470637867.953466 [0 195.168.1.1:52500] \"info\"" }
 
-  it "a pattern pass the grok expression" do
-    expect(grok).to pass
+    it "a pattern pass the grok expression" do
+      expect(grok).to pass
+    end
+
+    it "generates the timestamp field" do
+      expect(grok).to include("timestamp" => "1470637867.953466")
+    end
+
+    it "generates the database field" do
+      if ecs_compatibility?
+        expect(grok).to include("redis" => hash_including('database' => { 'id' => '0' }))
+      else
+        expect(grok).to include("database" => "0")
+      end
+    end
+
+    it "generates the client field" do
+      if ecs_compatibility?
+        expect(grok).to include("client" => hash_including('ip' => '195.168.1.1'))
+      else
+        expect(grok).to include("client" => "195.168.1.1")
+      end
+    end
+
+    it "generates the port field" do
+      if ecs_compatibility?
+        expect(grok).to include("client" => hash_including('port' => 52500))
+      else
+        expect(grok).to include("port" => "52500")
+      end
+    end
+
+    it "generates the command field" do
+      if ecs_compatibility?
+        expect(grok).to include("redis" => hash_including('command' => { 'name' => 'info' }))
+      else
+        expect(grok).to include("command" => "info")
+      end
+    end
+
   end
 
-  it "generates the timestamp field" do
-    expect(grok).to include("timestamp" => "1470637867.953466")
-  end
+  context "one param command" do
 
-  it "generates the database field" do
-    expect(grok).to include("database" => "0")
-  end
+    let(:message) { "1339518083.107412 [0 127.0.0.1:60866] \"keys\" \"*\"" }
 
-  it "generates the client field" do
-    expect(grok).to include("client" => "195.168.1.1")
-  end
+    it "a pattern pass the grok expression" do
+      expect(grok).to pass
+    end
 
-  it "generates the port field" do
-    expect(grok).to include("port" => "52500")
-  end
+    it "generates the timestamp field" do
+      expect(grok).to include("timestamp" => "1339518083.107412")
+    end
 
-  it "generates the command field" do
-    expect(grok).to include("command" => "info")
+    it "generates the database field" do
+      if ecs_compatibility?
+        expect(grok).to include("redis" => hash_including('database' => { 'id' => '0' }))
+      else
+        expect(grok).to include("database" => "0")
+      end
+    end
+
+    it "generates the client field" do
+      if ecs_compatibility?
+        expect(grok).to include("client" => hash_including('ip' => '127.0.0.1'))
+      else
+        expect(grok).to include("client" => "127.0.0.1")
+      end
+    end
+
+    it "generates the port field" do
+      if ecs_compatibility?
+        expect(grok).to include("client" => hash_including('port' => 60866))
+      else
+        expect(grok).to include("port" => "60866")
+      end
+    end
+
+    it "generates the command field" do
+      if ecs_compatibility?
+        expect(grok).to include("redis" => hash_including('command' => hash_including('name' => 'keys')))
+      else
+        expect(grok).to include("command" => "keys")
+      end
+    end
+
+    it "generates the params field" do
+      if ecs_compatibility?
+        expect(grok).to include("redis" => hash_including('command' => hash_including('args' => '"*"')))
+      else
+        expect(grok).to include("params" => "\"*\"")
+      end
+    end
+
   end
 
 end
 
-describe "REDISMONLOG - ONE PARAM COMMAND" do
+describe "REDISMONLOG (two param command)" do
 
-  let(:value)   { "1339518083.107412 [0 127.0.0.1:60866] \"keys\" \"*\"" }
   let(:pattern) { "REDISMONLOG" }
-  let(:grok)    { grok_match(pattern, value) }
-
-  it "a pattern pass the grok expression" do
-    expect(grok).to pass
-  end
-
-  it "generates the timestamp field" do
-    expect(grok).to include("timestamp" => "1339518083.107412")
-  end
-
-  it "generates the database field" do
-    expect(grok).to include("database" => "0")
-  end
-
-  it "generates the client field" do
-    expect(grok).to include("client" => "127.0.0.1")
-  end
-
-  it "generates the port field" do
-    expect(grok).to include("port" => "60866")
-  end
-
-  it "generates the command field" do
-    expect(grok).to include("command" => "keys")
-  end
-
-  it "generates the params field" do
-    expect(grok).to include("params" => "\"*\"")
-  end
-
-end
-
-describe "REDISMONLOG - TWO PARAM COMMAND" do
-
-  let(:value)   { "1470637925.186681 [0 127.0.0.1:39404] \"rpush\" \"my:special:key\" \"{\\\"data\\\":\"cdr\\\",\\\"payload\\\":\\\"json\\\"}\"" }
-  let(:pattern) { "REDISMONLOG" }
-  let(:grok)    { grok_match(pattern, value) }
+  let(:message) { "1470637925.186681 [0 127.0.0.1:39404] \"rpush\" \"my:special:key\" \"{\\\"data\\\":\"cdr\\\",\\\"payload\\\":\\\"json\\\"}\"" }
+  let(:grok)    { grok_match(pattern, message) }
 
   it "a pattern pass the grok expression" do
     expect(grok).to pass
@@ -134,11 +171,11 @@ describe "REDISMONLOG - TWO PARAM COMMAND" do
 
 end
 
-describe "REDISMONLOG - VARIADIC COMMAND" do
+describe "REDISMONLOG (variadic command)" do
 
-  let(:value)   { "1470637875.777457 [15 195.168.1.1:52500] \"intentionally\" \"broken\" \"variadic\" \"log\" \"entry\"" }
   let(:pattern) { "REDISMONLOG" }
-  let(:grok)    { grok_match(pattern, value) }
+  let(:message) { "1470637875.777457 [15 195.168.1.1:52500] \"intentionally\" \"broken\" \"variadic\" \"log\" \"entry\"" }
+  let(:grok)    { grok_match(pattern, message) }
 
   it "a pattern pass the grok expression" do
     expect(grok).to pass


### PR DESCRIPTION
... and shared spec helpers to ease testing in (2) different modes.

The shared helpers, when this is merged, are going to be used for other pattern migration specs ...
Did not split these into 2 PRs on purpose so that we have some spec usage in place.

*HINT: target is **ecs-wip** branch as this should get a **final review when all patterns** are migrated*
