### PR TITLE
Feat: ecs-ize postgresql named captures

### DIFF
--- a/patterns/ecs-v1/postgresql
+++ b/patterns/ecs-v1/postgresql
@@ -1,3 +1,2 @@
 # Default postgresql pg_log format pattern
-POSTGRESQL %{DATESTAMP:timestamp} %{TZ:[event][timezone]} %{DATA:[user][name]} %{GREEDYDATA:[postgresql][log][connection_id]} %{POSINT:[process][pid]}
-
+POSTGRESQL %{DATESTAMP:timestamp} %{TZ:[event][timezone]} %{DATA:[user][name]} %{GREEDYDATA:[postgresql][log][connection_id]} %{POSINT:[process][pid]:int}

--- a/patterns/ecs-v1/postgresql
+++ b/patterns/ecs-v1/postgresql
@@ -1,3 +1,3 @@
 # Default postgresql pg_log format pattern
-POSTGRESQL %{DATESTAMP:timestamp} %{TZ} %{DATA:user_id} %{GREEDYDATA:connection_id} %{POSINT:pid}
+POSTGRESQL %{DATESTAMP:timestamp} %{TZ:[event][timezone]} %{DATA:[user][name]} %{GREEDYDATA:[postgresql][log][connection_id]} %{POSINT:[process][pid]}
 


### PR DESCRIPTION
NOTE: `POSTGRESQL` format seems outdated compared to [beat's](https://github.com/elastic/beats/blob/7.8/filebeat/module/postgresql/log/ingest/pipeline.yml#L7)

*HINT: target is **ecs-wip** branch as this should get a **final review when all patterns** are migrated*