### PR TITLE
Feat: ecs-ize httpd patterns

### DIFF
--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -7,7 +7,7 @@ HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} "(?:-|%{DATA:[http][request][referrer]})" "
 
 # Error logs
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:[log][level]}\] (?:\[client %{IPORHOST:[source][address]}\] ){0,1}%{GREEDYDATA:message}
-HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]:int}(:tid %{INT:[process][thread][id]:int})?\]( \(%{POSINT:[apache][error][proxy][error_code]?}\)%{DATA:[apache][error][proxy][message]}:)?( \[client %{IPORHOST:[source][address]}:%{POSINT:[source][port]:int}\])?( %{DATA:[apache][error][error_code]}:)? %{GREEDYDATA:message}
+HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]:int}(:tid %{INT:[process][thread][id]:int})?\](:? \(%{POSINT:[apache][error][proxy][error_code]?}\)%{DATA:[apache][error][proxy][message]}:)?(:? \[client %{IPORHOST:[source][address]}:%{POSINT:[source][port]:int}\])?(:? %{DATA:[error][code]}:)? %{GREEDYDATA:message}
 HTTPD_ERRORLOG %{HTTPD20_ERRORLOG}|%{HTTPD24_ERRORLOG}
 
 # Deprecated

--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -2,7 +2,7 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:[source][address]} %{HTTPDUSER:[apache][access][user][identity]} %{HTTPDUSER:[user][name]} \[%{HTTPDATE:[apache][access][time]}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{NUMBER:[http][response][status_code]}) (?:-|%{NUMBER:[http][response][body][bytes]})
+HTTPD_COMMONLOG %{IPORHOST:[source][address]} %{HTTPDUSER:[apache][access][user][identity]} %{HTTPDUSER:[user][name]} \[%{HTTPDATE:[apache][access][time]}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{INT:[http][response][status_code]}) (?:-|%{INT:[http][response][body][bytes]})
 HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:[http][request][referrer]} %{QS:[user_agent][original]}
 
 # Error logs

--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -2,12 +2,12 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:[source][address]} %{HTTPDUSER:[apache][access][user][identity]} %{HTTPDUSER:[user][name]} \[%{HTTPDATE:[apache][access][time]}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{INT:[http][response][status_code]}) (?:-|%{INT:[http][response][body][bytes]})
+HTTPD_COMMONLOG %{IPORHOST:[source][address]} %{HTTPDUSER:[apache][access][user][identity]} %{HTTPDUSER:[user][name]} \[%{HTTPDATE:[apache][access][time]}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{INT:[http][response][status_code]:int}) (?:-|%{INT:[http][response][body][bytes]:int})
 HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:[http][request][referrer]} %{QS:[user_agent][original]}
 
 # Error logs
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:[log][level]}\] (?:\[client %{IPORHOST:[source][address]}\] ){0,1}%{GREEDYDATA:message}
-HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]}(:tid %{INT:[process][thread][id]})?\]( \(%{POSINT:[apache][error][proxy][error_code]?}\)%{DATA:[apache][error][proxy][message]}:)?( \[client %{IPORHOST:[source][address]}:%{POSINT:[source][port]}\])?( %{DATA:[apache][error][error_code]}:)? %{GREEDYDATA:message}
+HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]:int}(:tid %{INT:[process][thread][id]:int})?\]( \(%{POSINT:[apache][error][proxy][error_code]?}\)%{DATA:[apache][error][proxy][message]}:)?( \[client %{IPORHOST:[source][address]}:%{POSINT:[source][port]:int}\])?( %{DATA:[apache][error][error_code]}:)? %{GREEDYDATA:message}
 HTTPD_ERRORLOG %{HTTPD20_ERRORLOG}|%{HTTPD24_ERRORLOG}
 
 # Deprecated

--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -2,8 +2,8 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:[source][address]} %{HTTPDUSER:[apache][access][user][identity]} %{HTTPDUSER:[user][name]} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{INT:[http][response][status_code]:int}) (?:-|%{INT:[http][response][body][bytes]:int})
-HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:[http][request][referrer]} %{QS:[user_agent][original]}
+HTTPD_COMMONLOG %{IPORHOST:[source][address]} (?:-|%{HTTPDUSER:[apache][access][user][identity]}) (?:-|%{HTTPDUSER:[user][name]}) \[%{HTTPDATE:timestamp}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{INT:[http][response][status_code]:int}) (?:-|%{INT:[http][response][body][bytes]:int})
+HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} "(?:-|%{DATA:[http][request][referrer]})" "(?:-|%{DATA:[user_agent][original]})"
 
 # Error logs
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:[log][level]}\] (?:\[client %{IPORHOST:[source][address]}\] ){0,1}%{GREEDYDATA:message}

--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -6,8 +6,8 @@ HTTPD_COMMONLOG %{IPORHOST:[source][address]} (?:-|%{HTTPDUSER:[apache][access][
 HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} "(?:-|%{DATA:[http][request][referrer]})" "(?:-|%{DATA:[user_agent][original]})"
 
 # Error logs
-HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:[log][level]}\] (?:\[client %{IPORHOST:[source][address]}\] ){0,1}%{GREEDYDATA:message}
-HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]:int}(:tid %{INT:[process][thread][id]:int})?\](:? \(%{POSINT:[apache][error][proxy][error_code]?}\)%{DATA:[apache][error][proxy][message]}:)?(:? \[client %{IPORHOST:[source][address]}:%{POSINT:[source][port]:int}\])?(:? %{DATA:[error][code]}:)? %{GREEDYDATA:message}
+HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:[log][level]}\] (?:\[client %{IPORHOST:[source][address]}\] )?%{GREEDYDATA:message}
+HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]:int}(:tid %{INT:[process][thread][id]:int})?\](?: \(%{POSINT:[apache][error][proxy][error][code]?}\)%{DATA:[apache][error][proxy][error][message]}:)?(?: \[client %{IPORHOST:[source][address]}(?::%{POSINT:[source][port]:int})?\])?(?: %{DATA:[error][code]}:)? %{GREEDYDATA:message}
 HTTPD_ERRORLOG %{HTTPD20_ERRORLOG}|%{HTTPD24_ERRORLOG}
 
 # Deprecated

--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -7,7 +7,7 @@ HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:[http][request][referrer]} %{QS:[user_
 
 # Error logs
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:[log][level]}\] (?:\[client %{IPORHOST:[source][address]}\] ){0,1}%{GREEDYDATA:message}
-HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]}(:tid %{NUMBER:[trace][id]})?\]( \(%{POSINT:[apache][error][proxy][error_code]?}\)%{DATA:[apache][error][proxy][message]}:)?( \[client %{IPORHOST:[source][address]}:%{POSINT:[source][port]}\])?( %{DATA:[apache][error][error_code]}:)? %{GREEDYDATA:message}
+HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]}(:tid %{INT:[process][thread][id]})?\]( \(%{POSINT:[apache][error][proxy][error_code]?}\)%{DATA:[apache][error][proxy][message]}:)?( \[client %{IPORHOST:[source][address]}:%{POSINT:[source][port]}\])?( %{DATA:[apache][error][error_code]}:)? %{GREEDYDATA:message}
 HTTPD_ERRORLOG %{HTTPD20_ERRORLOG}|%{HTTPD24_ERRORLOG}
 
 # Deprecated

--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -2,12 +2,12 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:clientip} %{HTTPDUSER:ident} %{HTTPDUSER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" (?:-|%{NUMBER:response}) (?:-|%{NUMBER:bytes})
-HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:referrer} %{QS:agent}
+HTTPD_COMMONLOG %{IPORHOST:[source][address]} %{HTTPDUSER:[apache][access][user][identity]} %{HTTPDUSER:[user][name]} \[%{HTTPDATE:[apache][access][time]}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{NUMBER:[http][response][status_code]}) (?:-|%{NUMBER:[http][response][body][bytes]})
+HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:[http][request][referrer]} %{QS:[user_agent][original]}
 
 # Error logs
-HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:loglevel}\] (?:\[client %{IPORHOST:clientip}\] ){0,1}%{GREEDYDATA:message}
-HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:module}:%{LOGLEVEL:loglevel}\] \[pid %{POSINT:pid}(:tid %{NUMBER:tid})?\]( \(%{POSINT:proxy_errorcode}\)%{DATA:proxy_message}:)?( \[client %{IPORHOST:clientip}:%{POSINT:clientport}\])?( %{DATA:errorcode}:)? %{GREEDYDATA:message}
+HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:[log][level]}\] (?:\[client %{IPORHOST:[source][address]}\] ){0,1}%{GREEDYDATA:message}
+HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{WORD:[apache][error][module]}:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]}(:tid %{NUMBER:[trace][id]})?\]( \(%{POSINT:[apache][error][proxy][error_code]?}\)%{DATA:[apache][error][proxy][message]}:)?( \[client %{IPORHOST:[source][address]}:%{POSINT:[source][port]}\])?( %{DATA:[apache][error][error_code]}:)? %{GREEDYDATA:message}
 HTTPD_ERRORLOG %{HTTPD20_ERRORLOG}|%{HTTPD24_ERRORLOG}
 
 # Deprecated

--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -2,7 +2,7 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:[source][address]} %{HTTPDUSER:[apache][access][user][identity]} %{HTTPDUSER:[user][name]} \[%{HTTPDATE:[apache][access][time]}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{INT:[http][response][status_code]:int}) (?:-|%{INT:[http][response][body][bytes]:int})
+HTTPD_COMMONLOG %{IPORHOST:[source][address]} %{HTTPDUSER:[apache][access][user][identity]} %{HTTPDUSER:[user][name]} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:[http][request][method]} %{NOTSPACE:[url][original]}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA})" (?:-|%{INT:[http][response][status_code]:int}) (?:-|%{INT:[http][response][body][bytes]:int})
 HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:[http][request][referrer]} %{QS:[user_agent][original]}
 
 # Error logs

--- a/spec/patterns/httpd_spec.rb
+++ b/spec/patterns/httpd_spec.rb
@@ -110,7 +110,7 @@ describe_pattern "HTTPD_ERRORLOG", ['legacy', 'ecs-v1'] do
         expect(grok).to include("error" => { "code" => 'AH01075' })
         expect(grok).to include("apache" => { "error" => {
             "module" => "proxy_fcgi",
-            "proxy" => { "error_code" => '70008', "message" => "Partial results are valid but processing is incomplete" }}
+            "proxy" => { "error" => { "code" => '70008', "message" => "Partial results are valid but processing is incomplete" }}}
         })
       else
         expect(grok).to include(

--- a/spec/patterns/httpd_spec.rb
+++ b/spec/patterns/httpd_spec.rb
@@ -2,30 +2,51 @@
 require "spec_helper"
 require "logstash/patterns/core"
 
-describe "HTTPD_COMBINEDLOG" do
-
-  let(:pattern) { 'HTTPD_COMBINEDLOG' }
-  let(:grok) { grok_match(pattern, message) }
+describe_pattern "HTTPD_COMBINEDLOG", ['legacy', 'ecs-v1'] do
 
   context "typical test case" do
 
     let(:message) { '83.149.9.216 - - [24/Feb/2015:23:13:42 +0000] "GET /presentations/logstash-monitorama-2013/images/kibana-search.png HTTP/1.1" 200 203023 "http://semicomplete.com/presentations/logstash-monitorama-2013/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36"'}
 
     it "matches" do
-      expect(grok).to include(
-        'clientip' => '83.149.9.216',
-        'verb' => 'GET',
-        'request' => '/presentations/logstash-monitorama-2013/images/kibana-search.png',
-        'httpversion' => '1.1',
-        'response' => '200',
-        'bytes' => '203023',
-        'referrer' => '"http://semicomplete.com/presentations/logstash-monitorama-2013/"',
-        'agent' => '"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36"'
-      )
+      if ecs_compatibility?
+        expect(grok).to include(
+                            "http" => {
+                                "request" => {
+                                    "method" => "GET",
+                                    "referrer" => "http://semicomplete.com/presentations/logstash-monitorama-2013/"
+                                },
+                                "response" => {
+                                    "body" => { "bytes" => 203023 },
+                                    "status_code" => 200
+                                },
+                                "version"=>"1.1"
+                            },
+                            "source" => { "address" => "83.149.9.216" },
+                            "url" => { "original" => "/presentations/logstash-monitorama-2013/images/kibana-search.png" },
+                            "user_agent" => { "original" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36" }
+                        )
+      else
+        expect(grok).to include(
+                            'clientip' => '83.149.9.216',
+                            'verb' => 'GET',
+                            'request' => '/presentations/logstash-monitorama-2013/images/kibana-search.png',
+                            'httpversion' => '1.1',
+                            'response' => '200',
+                            'bytes' => '203023',
+                            'referrer' => '"http://semicomplete.com/presentations/logstash-monitorama-2013/"',
+                            'agent' => '"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36"'
+                        )
+      end
     end
 
     it "does not capture 'null' fields" do
-      expect(grok).to include('auth' => '-', 'ident' => '-')
+      if ecs_compatibility?
+        expect(grok.keys).to_not include('user') # 'user' => 'name'
+        expect(grok.keys).to_not include('apache') # apache.access.user.identity
+      else
+        expect(grok).to include('auth' => '-', 'ident' => '-')
+      end
     end
 
   end
@@ -35,7 +56,11 @@ describe "HTTPD_COMBINEDLOG" do
     let(:message) { '10.0.0.1 - username@example.com [07/Apr/2016:18:42:24 +0000] "GET /bar/foo/users/1/username%40example.com/authenticate?token=blargh&client_id=15 HTTP/1.1" 400 75 "" "Mozilla/5.0 (iPad; CPU OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13E238 Safari/601.1"'}
 
     it "gets captured" do
-      expect(grok).to include("auth" => "username@example.com")
+      if ecs_compatibility?
+        expect(grok).to include("user" => { 'name' => "username@example.com" })
+      else
+        expect(grok).to include("auth" => "username@example.com")
+      end
     end
 
   end
@@ -45,121 +70,195 @@ describe "HTTPD_COMBINEDLOG" do
     let(:message) { '83.149.9.216 - a.user [11/Jan/2020:23:05:27 +0100] "OPTIONS /remote.php/ HTTP/1.1" - 7908 "-" "monitoring-client (v2.2)"' }
 
     it 'matches' do
-      expect(grok).to include("verb" => "OPTIONS", 'request' => '/remote.php/', 'httpversion' => '1.1', "bytes" => '7908')
+      if ecs_compatibility?
+        expect(grok).to include("http" => hash_including("response" => hash_including("body" => { "bytes" => 7908 })))
+        expect(grok).to include("http" => hash_including("request" => { "method" => "OPTIONS" }, "version" => "1.1"))
+        expect(grok).to include(
+                            "url" => { "original" => "/remote.php/" },
+                            "user_agent" => { "original" => "monitoring-client (v2.2)" }
+                        )
+      else
+        expect(grok).to include("verb" => "OPTIONS", 'request' => '/remote.php/', 'httpversion' => '1.1', "bytes" => '7908')
+      end
     end
 
     it 'does not capture optional response code' do
-      expect(grok.keys).to_not include("response")
+      if ecs_compatibility?
+        expect(grok['http']['response'].keys).to_not include("status_code")
+      else
+        expect(grok.keys).to_not include("response")
+      end
     end
 
   end
 
 end
 
-describe "HTTPD_ERRORLOG" do
+describe_pattern "HTTPD_ERRORLOG", ['legacy', 'ecs-v1'] do
 
-  let(:pattern) { 'HTTPD_ERRORLOG' }
-  let(:grok) { grok_match(pattern, message) }
-
-  context "matches a full httpd 2.4 message" do
+  context "a full httpd 2.4 message" do
     let(:message) do
       "[Mon Aug 31 09:30:48.958285 2015] [proxy_fcgi:error] [pid 28787:tid 140169587934976] (70008)Partial results are valid but processing is incomplete: [client 58.13.45.166:59307] AH01075: Error dispatching request to : (reading input brigade), referer: http://example.com/index.php?id_product=11&controller=product"
     end
-    it "generates the fields" do
 
-      expect(grok).to include(
-        'timestamp' => 'Mon Aug 31 09:30:48.958285 2015',
-        'module' => 'proxy_fcgi',
-        'loglevel' => 'error',
-        'pid' => '28787',
-        'tid' => '140169587934976',
-        'proxy_errorcode' => '70008',
-        'proxy_message' => 'Partial results are valid but processing is incomplete',
-        'clientip' => '58.13.45.166',
-        'clientport' => '59307',
-        'errorcode' => 'AH01075',
-        'message' => [ message, 'Error dispatching request to : (reading input brigade), referer: http://example.com/index.php?id_product=11&controller=product' ],
-      )
+    it "generates the fields" do
+      expect(grok).to include('timestamp' => 'Mon Aug 31 09:30:48.958285 2015')
+      if ecs_compatibility?
+        expect(grok).to include("log" => { "level" => "error" })
+        expect(grok).to include("process" => { "pid" => 28787, "thread" => { "id" => 140169587934976 } })
+        expect(grok).to include("source" => { "address"=>"58.13.45.166", "port" => 59307 })
+        expect(grok).to include("error" => { "code" => 'AH01075' })
+        expect(grok).to include("apache" => { "error" => {
+            "module" => "proxy_fcgi",
+            "proxy" => { "error_code" => '70008', "message" => "Partial results are valid but processing is incomplete" }}
+        })
+      else
+        expect(grok).to include(
+                            'timestamp' => 'Mon Aug 31 09:30:48.958285 2015',
+                            'module' => 'proxy_fcgi',
+                            'loglevel' => 'error',
+                            'pid' => '28787',
+                            'tid' => '140169587934976',
+                            'proxy_errorcode' => '70008',
+                            'proxy_message' => 'Partial results are valid but processing is incomplete',
+                            'clientip' => '58.13.45.166',
+                            'clientport' => '59307',
+                            'errorcode' => 'AH01075'
+                            )
+      end
+      expect(grok).to include('message' => [ message, 'Error dispatching request to : (reading input brigade), referer: http://example.com/index.php?id_product=11&controller=product' ])
     end
   end
 
-  context "HTTPD_ERRORLOG", "matches a httpd 2.2 log message" do
+  context "a httpd 2.2 log message" do
     let(:message) do
       "[Mon Aug 31 16:27:04 2015] [error] [client 10.17.42.3] Premature end of script headers: example.com"
     end
+
     it "generates the fields" do
-      expect(grok).to include(
-        'timestamp' => 'Mon Aug 31 16:27:04 2015',
-        'loglevel' => 'error',
-        'clientip' => '10.17.42.3',
-        'message' => [ message, 'Premature end of script headers: example.com' ]
-      )
+      if ecs_compatibility?
+        expect(grok).to include(
+                            "timestamp"=>"Mon Aug 31 16:27:04 2015",
+                            "log"=>{"level"=>"error"},
+                            "source"=>{"address"=>"10.17.42.3"})
+        expect(grok.keys).to_not include("error") # error.code
+      else
+        expect(grok).to include(
+                            'timestamp' => 'Mon Aug 31 16:27:04 2015',
+                            'loglevel' => 'error',
+                            'clientip' => '10.17.42.3'
+                        )
+        expect(grok.keys).to_not include('errorcode')
+      end
+      expect(grok).to include('message' => [ message, 'Premature end of script headers: example.com' ])
     end
   end
 
-  context "HTTPD_ERRORLOG", "a short httpd 2.4 message" do
+  context "a short httpd 2.4 message" do
     let(:value1) {
       "[Mon Aug 31 07:15:38.664897 2015] [proxy_fcgi:error] [pid 28786:tid 140169629898496] [client 81.139.1.34:52042] AH01071: Got error 'Primary script unknown\n'"
     }
     it "generates the fields" do
-      expect(grok_match(subject, value1)).to include(
-        'timestamp' => 'Mon Aug 31 07:15:38.664897 2015',
-        'module' => 'proxy_fcgi',
-        'loglevel' => 'error',
-        'pid' => '28786',
-        'tid' => '140169629898496',
-        'clientip' => '81.139.1.34',
-        'clientport' => '52042',
-        'errorcode' => 'AH01071',
-        'message' => [ value1, "Got error 'Primary script unknown\n'" ]
-      )
+      match_result = grok_match(pattern, value1)
+      expect(match_result).to include('timestamp' => 'Mon Aug 31 07:15:38.664897 2015')
+      if ecs_compatibility?
+        expect(match_result).to include(
+                                    "apache"=>{"error"=>{"module"=>"proxy_fcgi"}},
+                                    "log"=>{"level"=>"error"},
+                                    "process"=>{"pid"=>28786, "thread"=>{"id"=>140169629898496}},
+                                    "source"=>{"address"=>"81.139.1.34", "port"=>52042},
+                                    "error"=>{"code"=>"AH01071"},
+                                )
+      else
+        expect(match_result).to include(
+                                    'module' => 'proxy_fcgi',
+                                    'loglevel' => 'error',
+                                    'pid' => '28786',
+                                    'tid' => '140169629898496',
+                                    'clientip' => '81.139.1.34',
+                                    'clientport' => '52042',
+                                    'errorcode' => 'AH01071'
+                                )
+      end
+      expect(match_result).to include('message' => [ value1, "Got error 'Primary script unknown\n'" ])
     end
 
     let(:value2) {
       "[Thu Apr 27 10:39:46.719636 2017] [php7:notice] [pid 17] [client 10.255.0.3:49580] Test error log record"
     }
-	it "generates the fields" do
-      expect(grok_match(subject, value2)).to include(
-        'timestamp' => 'Thu Apr 27 10:39:46.719636 2017',
-        'module' => 'php7',
-        'loglevel' => 'notice',
-        'pid' => '17',
-        'clientip' => '10.255.0.3',
-        'clientport' => '49580',
-        'message' => [ value2, "Test error log record" ]
-      )
+	  it "generates the fields" do
+      match_result = grok_match(pattern, value2)
+      expect(match_result).to include('timestamp' => 'Thu Apr 27 10:39:46.719636 2017')
+      if ecs_compatibility?
+        expect(match_result).to include(
+                                    "apache"=>{"error"=>{"module"=>"php7"}},
+                                    "log"=>{"level"=>"notice"},
+                                    "process"=>{"pid"=>17},
+                                    "source"=>{"port"=>49580, "address"=>"10.255.0.3"}
+                                )
+      else
+        expect(match_result).to include(
+                                    'module' => 'php7',
+                                    'loglevel' => 'notice',
+                                    'pid' => '17',
+                                    'clientip' => '10.255.0.3',
+                                    'clientport' => '49580'
+                                )
+      end
+      expect(match_result).to include('message' => [ value2, "Test error log record" ])
     end
   end
 
-  context "HTTPD_ERRORLOG", "a httpd 2.4 restart message" do
+  context "a httpd 2.4 restart message" do
     let(:value1) {
       "[Mon Aug 31 06:29:47.406518 2015] [mpm_event:notice] [pid 24968:tid 140169861986176] AH00489: Apache/2.4.16 (Ubuntu) configured -- resuming normal operations"
     }
     it "generates the fields" do
-      expect(grok_match(subject, value1)).to include(
-        'timestamp' => 'Mon Aug 31 06:29:47.406518 2015',
-        'module' => 'mpm_event',
-        'loglevel' => 'notice',
-        'pid' => '24968',
-        'tid' => '140169861986176',
-        'errorcode' => 'AH00489',
-        'message' => [ value1, 'Apache/2.4.16 (Ubuntu) configured -- resuming normal operations' ]
-      )
+      match_result = grok_match(pattern, value1)
+      expect(match_result).to include('timestamp' => 'Mon Aug 31 06:29:47.406518 2015')
+      if ecs_compatibility?
+        expect(match_result).to include(
+                                    "apache"=>{"error"=>{"module"=>"mpm_event"}},
+                                    "log"=>{"level"=>"notice"},
+                                    "process"=>{"pid"=>24968, "thread"=>{"id"=>140169861986176}},
+                                    "error"=>{"code"=>"AH00489"}
+                                )
+
+      else
+        expect(match_result).to include(
+                                    'module' => 'mpm_event',
+                                    'loglevel' => 'notice',
+                                    'pid' => '24968',
+                                    'tid' => '140169861986176',
+                                    'errorcode' => 'AH00489'
+                                )
+      end
+      expect(match_result).to include('message' => [ value1, 'Apache/2.4.16 (Ubuntu) configured -- resuming normal operations' ])
     end
 
     let(:value2) {
       "[Mon Aug 31 06:29:47.406530 2015] [core:notice] [pid 24968:tid 140169861986176] AH00094: Command line: '/usr/sbin/apache2'"
     }
     it "generates the fields" do
-      expect(grok_match(subject, value2)).to include(
-        'timestamp' => 'Mon Aug 31 06:29:47.406530 2015',
-        'module' => 'core',
-        'loglevel' => 'notice',
-        'pid' => '24968',
-        'tid' => '140169861986176',
-        'errorcode' => 'AH00094',
-        'message' => [ value2, 'Command line: \'/usr/sbin/apache2\'' ]
-      )
+      match_result = grok_match(pattern, value2)
+      expect(match_result).to include('timestamp' => 'Mon Aug 31 06:29:47.406530 2015')
+      if ecs_compatibility?
+        expect(match_result).to include(
+                                    "apache"=>{"error"=>{"module"=>"core"}},
+                                    "log"=>{"level"=>"notice"},
+                                    "process"=>{"pid"=>24968, "thread"=>{"id"=>140169861986176}},
+                                    "error"=>{"code"=>"AH00094"}
+                                )
+      else
+        expect(match_result).to include(
+                                    'module' => 'core',
+                                    'loglevel' => 'notice',
+                                    'pid' => '24968',
+                                    'tid' => '140169861986176',
+                                    'errorcode' => 'AH00094'
+                                )
+      end
+      expect(match_result).to include('message' => [ value2, 'Command line: \'/usr/sbin/apache2\'' ])
     end
   end
 
@@ -169,15 +268,20 @@ describe "HTTPD_ERRORLOG" do
     end
 
     it 'matches imperfectly (legacy)' do
-      expect(grok).to include({
-                                  "timestamp"=>"Fri Feb 01 22:03:08.319124 2019",
-                                  "module"=>"authz_core",
-                                  "loglevel"=>"debug",
-                                  "pid"=>"9",
-                                  "tid"=>"140597881775872",
-                                  "errorcode"=>"mod_authz_core.c(820)",
-                                  "message"=>[message, "[client 172.17.0.1:50752] AH01626: authorization result of <RequireAny>: granted"]
-                              })
+      if ecs_compatibility?
+        pending
+        raise NotImplementedError, "TODO: would be nice to 'improve' matching on these debug logs as well"
+      else
+        expect(grok).to include({
+                                    "timestamp"=>"Fri Feb 01 22:03:08.319124 2019",
+                                    "module"=>"authz_core",
+                                    "loglevel"=>"debug",
+                                    "pid"=>"9",
+                                    "tid"=>"140597881775872",
+                                    "errorcode"=>"mod_authz_core.c(820)",
+                                    "message"=>[message, "[client 172.17.0.1:50752] AH01626: authorization result of <RequireAny>: granted"]
+                                })
+      end
     end
   end
   


### PR DESCRIPTION
Beats already has support for [matching](https://github.com/elastic/beats/blob/v7.8.0/filebeat/module/apache/access/ingest/pipeline.yml) */var/log/httpd/access.log* where they're using the `apache.access` prefix for custom fields. 
~~There's no beats support for parsing the Apache error log, have tried using the same prefix convention which turns out a bit confusing e.g. `apache.error.error_code` as noted on the comments inline.~~

Also, yet again, LS' matching patterns seem outdated and could end up matching imperfectly (as seen in the demonstrated new spec). But this is out-of-scope here.

prerequisite: #282 