### PR TITLE
Feat: make java patterns match in an ecs compatible way

### DIFF
--- a/patterns/ecs-v1/java
+++ b/patterns/ecs-v1/java
@@ -4,7 +4,7 @@ JAVAFILE (?:[a-zA-Z$_0-9. -]+)
 #Allow special <init>, <clinit> methods
 JAVAMETHOD (?:(<(?:cl)?init>)|[a-zA-Z$_][a-zA-Z$_0-9]*)
 #Line number is optional in special cases 'Native method' or 'Unknown source'
-JAVASTACKTRACEPART %{SPACE}at %{JAVACLASS:class}\.%{JAVAMETHOD:method}\(%{JAVAFILE:file}(?::%{NUMBER:line})?\)
+JAVASTACKTRACEPART %{SPACE}at %{JAVACLASS:[java][log][origin][class_name]}\.%{JAVAMETHOD:[log][origin][function]}\(%{JAVAFILE:[log][origin][file][name]}(?::%{INT:[log][origin][file][line]:int})?\)
 # Java Logs
 JAVATHREAD (?:[A-Z]{2}-Processor[\d]+)
 JAVALOGMESSAGE (.*)
@@ -12,6 +12,6 @@ JAVALOGMESSAGE (.*)
 CATALINA_DATESTAMP %{MONTH} %{MONTHDAY}, 20%{YEAR} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) (?:AM|PM)
 # yyyy-MM-dd HH:mm:ss,SSS ZZZ eg: 2014-01-09 17:32:25,527 -0800
 TOMCAT_DATESTAMP 20%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) %{ISO8601_TIMEZONE}
-CATALINALOG %{CATALINA_DATESTAMP:timestamp} %{JAVACLASS:class} %{JAVALOGMESSAGE:logmessage}
+CATALINALOG %{CATALINA_DATESTAMP:timestamp} %{JAVACLASS:[java][log][origin][class][name]} %{JAVALOGMESSAGE:message}
 # 2014-01-09 20:03:28,269 -0800 | ERROR | com.example.service.ExampleService - something compeletely unexpected happened...
-TOMCATLOG %{TOMCAT_DATESTAMP:timestamp} \| %{LOGLEVEL:level} \| %{JAVACLASS:class} - %{JAVALOGMESSAGE:logmessage}
+TOMCATLOG %{TOMCAT_DATESTAMP:timestamp} \| %{LOGLEVEL:[log][level]} \| %{JAVACLASS:[java][log][origin][class][name]} - %{JAVALOGMESSAGE:message}

--- a/patterns/ecs-v1/java
+++ b/patterns/ecs-v1/java
@@ -21,17 +21,15 @@ CATALINA8_LOG %{CATALINA8_DATESTAMP:timestamp} %{LOGLEVEL:[log][level]} \[%{DATA
 CATALINA_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})
 CATALINALOG (?:%{CATALINA8_LOG})|(?:%{CATALINA7_LOG})
 
-# yyyy-MM-dd HH:mm:ss,SSS ZZZ e.g.: 2014-01-09 17:32:25,527 -0800
-# different from CATALINA_DATESTAMP in Tomcat 4.1/5.0 (since 5.5 it is the same)
-TOMCAT50_DATESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}(?: %{ISO8601_TIMEZONE})?
-TOMCAT50_LOG %{TOMCAT50_DATESTAMP:timestamp}(?: %{LOGLEVEL:[log][level]})? .*?\[%{DATA:[tomcat][context][name]}\](?:%{JAVACLASS:[java][log][origin][class][name]}: %{JAVAMETHOD:[log][origin][function]}\(.*?\))?(?:: %{JAVALOGMESSAGE:message})?
 # in Tomcat 5.5, 6.0, 7.0 it is the same as catalina.out logging format
-TOMCAT6_LOG %{CATALINA7_LOG}
+TOMCAT7_LOG %{CATALINA7_LOG}
 TOMCAT8_LOG %{CATALINA8_LOG}
 
 # NOTE: a weird log we started with - not sure what TC version this should match out of the box (due the | delimiters)
-TOMCATLEGACY_LOG %{TOMCAT50_DATESTAMP:timestamp} \| %{LOGLEVEL:[log][level]} \| %{JAVACLASS:[java][log][origin][class][name]} - %{JAVALOGMESSAGE:message}
+# TODO: we should simply drop this completely!
+TOMCATLEGACY_DATESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}(?: %{ISO8601_TIMEZONE})?
+TOMCATLEGACY_LOG %{TOMCATLEGACY_DATESTAMP:timestamp} \| %{LOGLEVEL:[log][level]} \| %{JAVACLASS:[java][log][origin][class][name]} - %{JAVALOGMESSAGE:message}
 
 TOMCAT_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})|(?:%{TOMCAT50_DATESTAMP})
 
-TOMCATLOG (?:%{TOMCAT8_LOG})|(?:%{TOMCAT6_LOG})|(?:%{TOMCAT50_LOG})|(?:%{TOMCATLEGACY_LOG})
+TOMCATLOG (?:%{TOMCAT8_LOG})|(?:%{TOMCAT7_LOG})|(?:%{TOMCATLEGACY_LOG})

--- a/patterns/ecs-v1/java
+++ b/patterns/ecs-v1/java
@@ -7,11 +7,11 @@ JAVAMETHOD (?:(<(?:cl)?init>)|[a-zA-Z$_][a-zA-Z$_0-9]*)
 JAVASTACKTRACEPART %{SPACE}at %{JAVACLASS:[java][log][origin][class][name]}\.%{JAVAMETHOD:[log][origin][function]}\(%{JAVAFILE:[log][origin][file][name]}(?::%{INT:[log][origin][file][line]:int})?\)
 # Java Logs
 JAVATHREAD (?:[A-Z]{2}-Processor[\d]+)
-JAVALOGMESSAGE (.*)
+JAVALOGMESSAGE (?:.*)
 
 # MMM dd, yyyy HH:mm:ss eg: Jan 9, 2014 7:13:13 AM
 # matches default logging configuration in Tomcat 4.1, 5.0, 5.5, 6.0, 7.0
-CATALINA7_DATESTAMP %{MONTH} %{MONTHDAY}, %{YEAR} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) (?:AM|PM)
+CATALINA7_DATESTAMP %{MONTH} %{MONTHDAY}, %{YEAR} %{HOUR}:%{MINUTE}:%{SECOND} (?:AM|PM)
 CATALINA7_LOG %{CATALINA7_DATESTAMP:timestamp} %{JAVACLASS:[java][log][origin][class][name]}(?: %{JAVAMETHOD:[log][origin][function]})?\s*(?:%{LOGLEVEL:[log][level]}:)? %{JAVALOGMESSAGE:message}
 
 # 31-Jul-2020 16:40:38.578 in Tomcat 8.5/9.0
@@ -21,7 +21,17 @@ CATALINA8_LOG %{CATALINA8_DATESTAMP:timestamp} %{LOGLEVEL:[log][level]} \[%{DATA
 CATALINA_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})
 CATALINALOG (?:%{CATALINA8_LOG})|(?:%{CATALINA7_LOG})
 
-# yyyy-MM-dd HH:mm:ss,SSS ZZZ eg: 2014-01-09 17:32:25,527 -0800
-# 2014-01-09 20:03:28,269 -0800 | ERROR | com.example.service.ExampleService - something compeletely unexpected happened...
-TOMCATLOG %{TOMCAT_DATESTAMP:timestamp} \| %{LOGLEVEL:[log][level]} \| %{JAVACLASS:[java][log][origin][class][name]} - %{JAVALOGMESSAGE:message}
-TOMCAT_DATESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) %{ISO8601_TIMEZONE}
+# yyyy-MM-dd HH:mm:ss,SSS ZZZ e.g.: 2014-01-09 17:32:25,527 -0800
+# different from CATALINA_DATESTAMP in Tomcat 4.1/5.0 (since 5.5 it is the same)
+TOMCAT50_DATESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}(?: %{ISO8601_TIMEZONE})?
+TOMCAT50_LOG %{TOMCAT50_DATESTAMP:timestamp}(?: %{LOGLEVEL:[log][level]})? .*?\[%{DATA:[tomcat][context][name]}\](?:%{JAVACLASS:[java][log][origin][class][name]}: %{JAVAMETHOD:[log][origin][function]}\(.*?\))?(?:: %{JAVALOGMESSAGE:message})?
+# in Tomcat 5.5, 6.0, 7.0 it is the same as catalina.out logging format
+TOMCAT6_LOG %{CATALINA7_LOG}
+TOMCAT8_LOG %{CATALINA8_LOG}
+
+# NOTE: a weird log we started with - not sure what TC version this should match out of the box (due the | delimiters)
+TOMCATLEGACY_LOG %{TOMCAT50_DATESTAMP:timestamp} \| %{LOGLEVEL:[log][level]} \| %{JAVACLASS:[java][log][origin][class][name]} - %{JAVALOGMESSAGE:message}
+
+TOMCAT_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})|(?:%{TOMCAT50_DATESTAMP})
+
+TOMCATLOG (?:%{TOMCAT8_LOG})|(?:%{TOMCAT6_LOG})|(?:%{TOMCAT50_LOG})|(?:%{TOMCATLEGACY_LOG})

--- a/patterns/ecs-v1/java
+++ b/patterns/ecs-v1/java
@@ -26,10 +26,9 @@ TOMCAT7_LOG %{CATALINA7_LOG}
 TOMCAT8_LOG %{CATALINA8_LOG}
 
 # NOTE: a weird log we started with - not sure what TC version this should match out of the box (due the | delimiters)
-# TODO: we should simply drop this completely!
 TOMCATLEGACY_DATESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:%{MINUTE}:%{SECOND}(?: %{ISO8601_TIMEZONE})?
 TOMCATLEGACY_LOG %{TOMCATLEGACY_DATESTAMP:timestamp} \| %{LOGLEVEL:[log][level]} \| %{JAVACLASS:[java][log][origin][class][name]} - %{JAVALOGMESSAGE:message}
 
-TOMCAT_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})|(?:%{TOMCAT50_DATESTAMP})
+TOMCAT_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})|(?:%{TOMCATLEGACY_DATESTAMP})
 
 TOMCATLOG (?:%{TOMCAT8_LOG})|(?:%{TOMCAT7_LOG})|(?:%{TOMCATLEGACY_LOG})

--- a/patterns/ecs-v1/java
+++ b/patterns/ecs-v1/java
@@ -4,7 +4,7 @@ JAVAFILE (?:[a-zA-Z$_0-9. -]+)
 #Allow special <init>, <clinit> methods
 JAVAMETHOD (?:(<(?:cl)?init>)|[a-zA-Z$_][a-zA-Z$_0-9]*)
 #Line number is optional in special cases 'Native method' or 'Unknown source'
-JAVASTACKTRACEPART %{SPACE}at %{JAVACLASS:[java][log][origin][class_name]}\.%{JAVAMETHOD:[log][origin][function]}\(%{JAVAFILE:[log][origin][file][name]}(?::%{INT:[log][origin][file][line]:int})?\)
+JAVASTACKTRACEPART %{SPACE}at %{JAVACLASS:[java][log][origin][class][name]}\.%{JAVAMETHOD:[log][origin][function]}\(%{JAVAFILE:[log][origin][file][name]}(?::%{INT:[log][origin][file][line]:int})?\)
 # Java Logs
 JAVATHREAD (?:[A-Z]{2}-Processor[\d]+)
 JAVALOGMESSAGE (.*)

--- a/patterns/ecs-v1/java
+++ b/patterns/ecs-v1/java
@@ -8,10 +8,20 @@ JAVASTACKTRACEPART %{SPACE}at %{JAVACLASS:[java][log][origin][class][name]}\.%{J
 # Java Logs
 JAVATHREAD (?:[A-Z]{2}-Processor[\d]+)
 JAVALOGMESSAGE (.*)
+
 # MMM dd, yyyy HH:mm:ss eg: Jan 9, 2014 7:13:13 AM
-CATALINA_DATESTAMP %{MONTH} %{MONTHDAY}, 20%{YEAR} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) (?:AM|PM)
+# matches default logging configuration in Tomcat 4.1, 5.0, 5.5, 6.0, 7.0
+CATALINA7_DATESTAMP %{MONTH} %{MONTHDAY}, %{YEAR} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) (?:AM|PM)
+CATALINA7_LOG %{CATALINA7_DATESTAMP:timestamp} %{JAVACLASS:[java][log][origin][class][name]}(?: %{JAVAMETHOD:[log][origin][function]})?\s*(?:%{LOGLEVEL:[log][level]}:)? %{JAVALOGMESSAGE:message}
+
+# 31-Jul-2020 16:40:38.578 in Tomcat 8.5/9.0
+CATALINA8_DATESTAMP %{MONTHDAY}-%{MONTH}-%{YEAR} %{HOUR}:%{MINUTE}:%{SECOND}
+CATALINA8_LOG %{CATALINA8_DATESTAMP:timestamp} %{LOGLEVEL:[log][level]} \[%{DATA:[java][log][origin][thread][name]}\] %{JAVACLASS:[java][log][origin][class][name]}\.(?:%{JAVAMETHOD:[log][origin][function]})? %{JAVALOGMESSAGE:message}
+
+CATALINA_DATESTAMP (?:%{CATALINA8_DATESTAMP})|(?:%{CATALINA7_DATESTAMP})
+CATALINALOG (?:%{CATALINA8_LOG})|(?:%{CATALINA7_LOG})
+
 # yyyy-MM-dd HH:mm:ss,SSS ZZZ eg: 2014-01-09 17:32:25,527 -0800
-TOMCAT_DATESTAMP 20%{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) %{ISO8601_TIMEZONE}
-CATALINALOG %{CATALINA_DATESTAMP:timestamp} %{JAVACLASS:[java][log][origin][class][name]} %{JAVALOGMESSAGE:message}
 # 2014-01-09 20:03:28,269 -0800 | ERROR | com.example.service.ExampleService - something compeletely unexpected happened...
 TOMCATLOG %{TOMCAT_DATESTAMP:timestamp} \| %{LOGLEVEL:[log][level]} \| %{JAVACLASS:[java][log][origin][class][name]} - %{JAVALOGMESSAGE:message}
+TOMCAT_DATESTAMP %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{HOUR}:?%{MINUTE}(?::?%{SECOND}) %{ISO8601_TIMEZONE}

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -54,15 +54,6 @@ describe "HTTP DATE parsing" do
 
 end
 
-describe "TOMCATLOG" do
-
-  let(:value) { '2014-01-09 20:03:28,269 -0800 | ERROR | com.example.service.ExampleService - something compeletely unexpected happened...'}
-
-  it "generates the logmessage field" do
-    expect(grok_match(subject, value)).to include("logmessage" => "something compeletely unexpected happened...")
-  end
-end
-
 describe 'LOGLEVEL' do
   it 'matches info label' do
     expect(grok_match(subject, 'INFO')).to pass

--- a/spec/patterns/java_spec.rb
+++ b/spec/patterns/java_spec.rb
@@ -55,6 +55,132 @@ describe_pattern "JAVASTACKTRACEPART", [ 'legacy', 'ecs-v1' ] do
 
 end
 
+describe_pattern "CATALINALOG", [ 'legacy', 'ecs-v1' ] do
+
+  context 'Tomcat 4.1' do
+
+    let(:message) do
+      "Dec 30, 2020 11:30:40 AM org.apache.struts.util.PropertyMessageResources <init>\n" +
+          "INFO: Initializing, config='org.apache.struts.util.LocalStrings', returnNull=true"
+    end
+
+    it "matches" do
+      expect(subject).to include "timestamp"=>"Dec 30, 2020 11:30:40 AM"
+      if ecs_compatibility?
+        expect(subject).to include "java"=>{"log"=>{"origin"=>{"class"=>{"name"=>"org.apache.struts.util.PropertyMessageResources"}}}},
+                                   "log"=>{"level"=>"INFO", "origin"=>{"function"=>"<init>"}}
+
+        expect(subject).to include "message"=>[message, "Initializing, config='org.apache.struts.util.LocalStrings', returnNull=true"]
+      else
+        expect(subject).to include "class"=>"org.apache.struts.util.PropertyMessageResources",
+                                   "logmessage"=>"<init>\nINFO: Initializing, config='org.apache.struts.util.LocalStrings', returnNull=true"
+      end
+    end
+
+  end
+
+  context 'Tomcat 6.0' do # ~ same for Tomcat 4.x - 7.x
+
+    let(:message) do
+      "Jul 30, 2020 3:00:21 PM org.apache.coyote.http11.Http11Protocol init\nINFO: Initializing Coyote HTTP/1.1 on http-8080"
+    end
+
+    it "matches" do
+      expect(subject).to include "timestamp"=>"Jul 30, 2020 3:00:21 PM"
+      if ecs_compatibility?
+        expect(subject).to include "java"=>{"log"=>{"origin"=>{"class"=>{"name"=>"org.apache.coyote.http11.Http11Protocol"}}}},
+                                   "log"=>{"level"=>"INFO", "origin"=>{"function"=>"init"}}
+
+        expect(subject).to include "message"=>[message, "Initializing Coyote HTTP/1.1 on http-8080"]
+      else
+        expect(subject).to include "class"=>"org.apache.coyote.http11.Http11Protocol",
+                                   "logmessage" => "init\nINFO: Initializing Coyote HTTP/1.1 on http-8080"
+      end
+    end
+
+  end
+
+  context 'Tomcat 9.0' do # same for Tomcat 8.5
+
+    let(:message) do
+      "31-Jul-2020 16:40:38.505 INFO [localhost-startStop-1] org.apache.catalina.startup.HostConfig.deployDirectory " +
+          "Deployment of web application directory [/opt/temp/apache-tomcat-8.5.57/webapps/ROOT] has finished in [40] ms"
+    end
+
+    it "matches" do
+      if ecs_compatibility?
+        expect(subject).to include "timestamp"=>"31-Jul-2020 16:40:38.505"
+
+        expect(subject).to include "java"=>{"log"=>{"origin"=>{
+                                      "thread"=>{"name"=>"localhost-startStop-1"},
+                                      "class"=>{"name"=>"org.apache.catalina.startup.HostConfig"}}}},
+                                   "log"=>{"level"=>"INFO", "origin"=>{"function"=>"deployDirectory"}}
+
+        expect(subject).to include "message"=>[message, "Deployment of web application directory [/opt/temp/apache-tomcat-8.5.57/webapps/ROOT] has finished in [40] ms"]
+      else
+        # not supported in legacy mode
+      end
+    end
+
+  end
+
+  context 'multiline stack-trace' do
+
+  let(:message) do
+<<LINE
+30-Dec-2020 11:44:31.277 SEVERE [main] org.apache.catalina.util.LifecycleBase.handleSubClassException Failed to initialize component [Connector[HTTP/1.1-8080]]
+	org.apache.catalina.LifecycleException: Protocol handler initialization failed
+		at org.apache.catalina.connector.Connector.initInternal(Connector.java:1042)
+		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:136)
+		at org.apache.catalina.core.StandardService.initInternal(StandardService.java:533)
+		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:136)
+		at org.apache.catalina.core.StandardServer.initInternal(StandardServer.java:1057)
+		at org.apache.catalina.util.LifecycleBase.init(LifecycleBase.java:136)
+		at org.apache.catalina.startup.Catalina.load(Catalina.java:690)
+		at org.apache.catalina.startup.Catalina.load(Catalina.java:712)
+		at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+		at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
+		at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+		at java.lang.reflect.Method.invoke(Method.java:498)
+		at org.apache.catalina.startup.Bootstrap.load(Bootstrap.java:302)
+		at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:472)
+	Caused by: java.net.BindException: Address already in use
+		at sun.nio.ch.Net.bind0(Native Method)
+		at sun.nio.ch.Net.bind(Net.java:433)
+		at sun.nio.ch.Net.bind(Net.java:425)
+		at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223)
+		at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74)
+		at org.apache.tomcat.util.net.NioEndpoint.initServerSocket(NioEndpoint.java:228)
+		at org.apache.tomcat.util.net.NioEndpoint.bind(NioEndpoint.java:211)
+		at org.apache.tomcat.util.net.AbstractEndpoint.bindWithCleanup(AbstractEndpoint.java:1141)
+		at org.apache.tomcat.util.net.AbstractEndpoint.init(AbstractEndpoint.java:1154)
+		at org.apache.coyote.AbstractProtocol.init(AbstractProtocol.java:581)
+		at org.apache.coyote.http11.AbstractHttp11Protocol.init(AbstractHttp11Protocol.java:74)
+		at org.apache.catalina.connector.Connector.initInternal(Connector.java:1039)
+		... 13 more
+LINE
+  end
+
+  it "matches" do
+    if ecs_compatibility?
+      expect(subject).to include "timestamp"=>"30-Dec-2020 11:44:31.277"
+
+      expect(subject).to include "java"=>{"log"=>{"origin"=>{
+                                    "thread"=>{"name"=>"main"},
+                                    "class"=>{"name"=>"org.apache.catalina.util.LifecycleBase"}}}},
+                                 "log"=>{"level"=>"SEVERE", "origin"=>{"function"=>"handleSubClassException"}}
+
+      expect(subject['message'][0]).to eql message
+      expect(subject['message'][1]).to start_with 'Failed to initialize component [Connector[HTTP/1.1-8080]]'
+    else
+      # not supported in legacy mode
+    end
+  end
+
+  end
+
+end
+
 describe_pattern "TOMCATLOG", [ 'legacy', 'ecs-v1' ] do
 
   context 'example format' do

--- a/spec/patterns/java_spec.rb
+++ b/spec/patterns/java_spec.rb
@@ -340,3 +340,36 @@ LINE
   end
 
 end
+
+describe_pattern "TOMCAT_DATESTAMP", [ 'legacy', 'ecs-v1' ] do
+
+  context '<= 7.0 format' do
+
+    let(:message) { 'Jul 31, 2020 4:40:20 PM' }
+
+    it "matches" do
+      expect(grok_match(pattern, message, true)['tags']).to be nil if ecs_compatibility?
+    end
+
+  end
+
+  context '>= 8.0 format' do
+
+    let(:message) { '30-Jun-2020 16:40:38.451' }
+
+    it "matches" do
+      expect(grok_match(pattern, message, true)['tags']).to be nil if ecs_compatibility?
+    end
+
+  end
+
+  context 'legacy format' do
+
+    let(:message) { '2014-01-09 20:03:28,269 -0800' }
+
+    it "matches" do
+      expect(grok_match(pattern, message, true)['tags']).to be nil
+    end
+
+  end
+end

--- a/spec/patterns/java_spec.rb
+++ b/spec/patterns/java_spec.rb
@@ -22,7 +22,7 @@ describe_pattern "JAVASTACKTRACEPART", [ 'legacy', 'ecs-v1' ] do
     if ecs_compatibility?
       expect(grok).to include(
                           "log" => { "origin" => { "function" => 'aMethod', "file" => { "name" => 'StackTraceExample.java', "line" => 42 } } },
-                          "java" => { "log" => { "origin" => { "class_name" => 'com.sample.stacktrace.StackTraceExample' } } }
+                          "java" => { "log" => { "origin" => { "class" => { "name" => 'com.sample.stacktrace.StackTraceExample' } } } }
                       )
     else
       expect(grok).to include(

--- a/spec/patterns/java_spec.rb
+++ b/spec/patterns/java_spec.rb
@@ -20,12 +20,12 @@ describe_pattern "JAVASTACKTRACEPART", [ 'legacy', 'ecs-v1' ] do
 
   it "matches" do
     if ecs_compatibility?
-      expect(grok).to include(
+      expect(subject).to include(
                           "log" => { "origin" => { "function" => 'aMethod', "file" => { "name" => 'StackTraceExample.java', "line" => 42 } } },
                           "java" => { "log" => { "origin" => { "class" => { "name" => 'com.sample.stacktrace.StackTraceExample' } } } }
                       )
     else
-      expect(grok).to include(
+      expect(subject).to include(
                           "message"=>"  at com.sample.stacktrace.StackTraceExample.aMethod(StackTraceExample.java:42)",
                           "method"=>"aMethod",
                           "class"=>"com.sample.stacktrace.StackTraceExample",
@@ -38,12 +38,18 @@ describe_pattern "JAVASTACKTRACEPART", [ 'legacy', 'ecs-v1' ] do
   context 'generated file' do
     let(:message) { '  at org.jruby.RubyMethod$INVOKER$i$call.call(RubyMethod$INVOKER$i$call.gen)' }
     it "matches" do
-      grok = grok_match(pattern, message, true)
-      expect(grok).to include({
-                                  "method"=>"call",
-                                  "class"=>"org.jruby.RubyMethod$INVOKER$i$call",
-                                  "file"=>"RubyMethod$INVOKER$i$call.gen",
-                              })
+      if ecs_compatibility?
+        expect(subject).to include(
+                               "log"=>{"origin"=>{"function"=>"call", "file"=>{"name"=>"RubyMethod$INVOKER$i$call.gen"}}},
+                               "java"=>{"log"=>{"origin"=>{"class"=>{"name"=>"org.jruby.RubyMethod$INVOKER$i$call"}}}}
+                           )
+      else
+        expect(subject).to include({
+                                    "method"=>"call",
+                                    "class"=>"org.jruby.RubyMethod$INVOKER$i$call",
+                                    "file"=>"RubyMethod$INVOKER$i$call.gen",
+                                })
+      end
     end
   end
 end

--- a/spec/patterns/java_spec.rb
+++ b/spec/patterns/java_spec.rb
@@ -181,38 +181,38 @@ LINE
 
 end
 
-describe_pattern "TOMCAT50_LOG", [ 'ecs-v1' ] do
-
-  context 'with message' do # Tomcat 4.1
-
-    let(:message) do
-      '2020-12-30 11:30:40 StandardManager[/admin]: Seeding random number generator class java.security.SecureRandom'
-    end
-
-    it "matches" do
-      expect(subject).to include "timestamp"=>"2020-12-30 11:30:40",
-                                 "message"=>[message, "Seeding random number generator class java.security.SecureRandom"],
-                                 "tomcat"=>{"context"=>{"name"=>"/admin"}}
-    end
-
-  end
-
-  context 'wout message' do # Tomcat 5.0
-
-    let(:message) do
-      '2020-12-30 11:28:14 StandardContext[/jsp-examples]ContextListener: contextDestroyed()'
-    end
-
-    it "matches" do
-      expect(subject).to include "timestamp"=>"2020-12-30 11:28:14",
-                                 "log"=>{"origin"=>{"function"=>"contextDestroyed"}},
-                                 "java"=>{"log"=>{"origin"=>{"class"=>{"name"=>"ContextListener"}}}},
-                                 "tomcat"=>{"context"=>{"name"=>"/jsp-examples"}}
-    end
-
-  end
-
-end
+# describe_pattern "TOMCAT50_LOG", [ 'ecs-v1' ] do
+#
+#   context 'with message' do # Tomcat 4.1
+#
+#     let(:message) do
+#       '2020-12-30 11:30:40 StandardManager[/admin]: Seeding random number generator class java.security.SecureRandom'
+#     end
+#
+#     it "matches" do
+#       expect(subject).to include "timestamp"=>"2020-12-30 11:30:40",
+#                                  "message"=>[message, "Seeding random number generator class java.security.SecureRandom"],
+#                                  "tomcat"=>{"context"=>{"name"=>"/admin"}}
+#     end
+#
+#   end
+#
+#   context 'wout message' do # Tomcat 5.0
+#
+#     let(:message) do
+#       '2020-12-30 11:28:14 StandardContext[/jsp-examples]ContextListener: contextDestroyed()'
+#     end
+#
+#     it "matches" do
+#       expect(subject).to include "timestamp"=>"2020-12-30 11:28:14",
+#                                  "log"=>{"origin"=>{"function"=>"contextDestroyed"}},
+#                                  "java"=>{"log"=>{"origin"=>{"class"=>{"name"=>"ContextListener"}}}},
+#                                  "tomcat"=>{"context"=>{"name"=>"/jsp-examples"}}
+#     end
+#
+#   end
+#
+# end
 
 describe_pattern "TOMCATLOG", [ 'legacy', 'ecs-v1' ] do
 

--- a/spec/patterns/java_spec.rb
+++ b/spec/patterns/java_spec.rb
@@ -52,4 +52,35 @@ describe_pattern "JAVASTACKTRACEPART", [ 'legacy', 'ecs-v1' ] do
       end
     end
   end
+
+end
+
+describe_pattern "TOMCATLOG", [ 'legacy', 'ecs-v1' ] do
+
+  context 'example format' do
+
+    let(:message) do
+      '2014-01-09 20:03:28,269 -0800 | ERROR | com.example.service.ExampleService - something compeletely unexpected happened...'
+    end
+
+    it "matches" do
+      expect(subject).to include "timestamp"=>"2014-01-09 20:03:28,269 -0800"
+      if ecs_compatibility?
+        expect(subject).to include "log"=>{"level"=>"ERROR"},
+                                   "java"=>{"log"=>{"origin"=>{"class"=>{"name"=>"com.example.service.ExampleService"}}}}
+      else
+        expect(subject).to include "level"=>"ERROR"
+      end
+    end
+
+    it "'generates' the message field" do
+      if ecs_compatibility?
+        expect(subject).to include "message"=>[message, "something compeletely unexpected happened..."]
+      else
+        expect(subject).to include("logmessage" => "something compeletely unexpected happened...")
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION
should be straightforward except 2 hiccups:
- Java class-name capture naming (no ECS convention really)
- `message` sub-part wasn't being matched (appended) to `message` but rather to `logmessage`
   which I believe is good but we did not yet decide whether that's a convention to follow
   (in which case it should be followed for all ecs-ized patterns -> namespacing sub-message part)
   
---

resolves https://github.com/logstash-plugins/logstash-patterns-core/issues/123 closing https://github.com/logstash-plugins/logstash-patterns-core/pull/244