### PR TITLE
Feat: ecs-ize MongoDB pattern captures

### DIFF
--- a/patterns/ecs-v1/mongodb
+++ b/patterns/ecs-v1/mongodb
@@ -1,7 +1,7 @@
-MONGO_LOG %{SYSLOGTIMESTAMP:timestamp} \[%{WORD:component}\] %{GREEDYDATA:message}
+MONGO_LOG %{SYSLOGTIMESTAMP:timestamp} \[%{WORD:[mongodb][component]}\] %{GREEDYDATA:message}
 MONGO_QUERY \{ (?<={ ).*(?= } ntoreturn:) \}
-MONGO_SLOWQUERY %{WORD} %{MONGO_WORDDASH:database}\.%{MONGO_WORDDASH:collection} %{WORD}: %{MONGO_QUERY:query} %{WORD}:%{NONNEGINT:ntoreturn} %{WORD}:%{NONNEGINT:ntoskip} %{WORD}:%{NONNEGINT:nscanned}.*nreturned:%{NONNEGINT:nreturned}..+ (?<duration>[0-9]+)ms
+MONGO_SLOWQUERY %{WORD:[mongodb][profile][op]} %{MONGO_WORDDASH:[mongodb][database]}\.%{MONGO_WORDDASH:[mongodb][collection]} %{WORD}: %{MONGO_QUERY:[mongodb][query][original]} %{WORD}:%{NONNEGINT:[mongodb][profile][ntoreturn]:int} %{WORD}:%{NONNEGINT:[mongodb][profile][ntoskip]:int} %{WORD}:%{NONNEGINT:[mongodb][profile][nscanned]:int}.*nreturned:%{NONNEGINT:[mongodb][profile][nreturned]:int}..+ (?<[mongodb][profile][duration]:int>[0-9]+)ms
 MONGO_WORDDASH \b[\w-]+\b
 MONGO3_SEVERITY \w
 MONGO3_COMPONENT %{WORD}|-
-MONGO3_LOG %{TIMESTAMP_ISO8601:timestamp} %{MONGO3_SEVERITY:severity} %{MONGO3_COMPONENT:component}%{SPACE}(?:\[%{DATA:context}\])? %{GREEDYDATA:message}
+MONGO3_LOG %{TIMESTAMP_ISO8601:timestamp} %{MONGO3_SEVERITY:[log][level]} %{MONGO3_COMPONENT:[mongodb][component]}%{SPACE}(?:\[%{DATA:[mongodb][context]}\])? %{GREEDYDATA:message}

--- a/patterns/ecs-v1/mongodb
+++ b/patterns/ecs-v1/mongodb
@@ -1,6 +1,6 @@
 MONGO_LOG %{SYSLOGTIMESTAMP:timestamp} \[%{WORD:[mongodb][component]}\] %{GREEDYDATA:message}
 MONGO_QUERY \{ (?<={ ).*(?= } ntoreturn:) \}
-MONGO_SLOWQUERY %{WORD:[mongodb][profile][op]} %{MONGO_WORDDASH:[mongodb][database]}\.%{MONGO_WORDDASH:[mongodb][collection]} %{WORD}: %{MONGO_QUERY:[mongodb][query][original]} %{WORD}:%{NONNEGINT:[mongodb][profile][ntoreturn]:int} %{WORD}:%{NONNEGINT:[mongodb][profile][ntoskip]:int} %{WORD}:%{NONNEGINT:[mongodb][profile][nscanned]:int}.*nreturned:%{NONNEGINT:[mongodb][profile][nreturned]:int}..+ (?<[mongodb][profile][duration]:int>[0-9]+)ms
+MONGO_SLOWQUERY %{WORD:[mongodb][profile][op]} %{MONGO_WORDDASH:[mongodb][database]}\.%{MONGO_WORDDASH:[mongodb][collection]} %{WORD}: %{MONGO_QUERY:[mongodb][query][original]} ntoreturn:%{NONNEGINT:[mongodb][profile][ntoreturn]:int} ntoskip:%{NONNEGINT:[mongodb][profile][ntoskip]:int} nscanned:%{NONNEGINT:[mongodb][profile][nscanned]:int}.*? nreturned:%{NONNEGINT:[mongodb][profile][nreturned]:int}.*? %{INT:[mongodb][profile][duration]:int}ms
 MONGO_WORDDASH \b[\w-]+\b
 MONGO3_SEVERITY \w
 MONGO3_COMPONENT %{WORD}|-

--- a/patterns/ecs-v1/mongodb
+++ b/patterns/ecs-v1/mongodb
@@ -3,5 +3,5 @@ MONGO_QUERY \{ (?<={ ).*(?= } ntoreturn:) \}
 MONGO_SLOWQUERY %{WORD:[mongodb][profile][op]} %{MONGO_WORDDASH:[mongodb][database]}\.%{MONGO_WORDDASH:[mongodb][collection]} %{WORD}: %{MONGO_QUERY:[mongodb][query][original]} ntoreturn:%{NONNEGINT:[mongodb][profile][ntoreturn]:int} ntoskip:%{NONNEGINT:[mongodb][profile][ntoskip]:int} nscanned:%{NONNEGINT:[mongodb][profile][nscanned]:int}.*? nreturned:%{NONNEGINT:[mongodb][profile][nreturned]:int}.*? %{INT:[mongodb][profile][duration]:int}ms
 MONGO_WORDDASH \b[\w-]+\b
 MONGO3_SEVERITY \w
-MONGO3_COMPONENT %{WORD}|-
-MONGO3_LOG %{TIMESTAMP_ISO8601:timestamp} %{MONGO3_SEVERITY:[log][level]} %{MONGO3_COMPONENT:[mongodb][component]}%{SPACE}(?:\[%{DATA:[mongodb][context]}\])? %{GREEDYDATA:message}
+MONGO3_COMPONENT %{WORD}
+MONGO3_LOG %{TIMESTAMP_ISO8601:timestamp} %{MONGO3_SEVERITY:[log][level]} (?:-|%{MONGO3_COMPONENT:[mongodb][component]})%{SPACE}(?:\[%{DATA:[mongodb][context]}\])? %{GREEDYDATA:message}

--- a/spec/patterns/mongodb_spec.rb
+++ b/spec/patterns/mongodb_spec.rb
@@ -2,83 +2,193 @@
 require "spec_helper"
 require "logstash/patterns/core"
 
-describe "MONGO3_LOG" do
-
-  let(:pattern)    { "MONGO3_LOG" }
+describe_pattern "MONGO3_LOG", ['legacy', 'ecs-v1'] do
 
   context "parsing an standard/basic message" do
 
-    let(:value) { "2014-11-03T18:28:32.450-0500 I NETWORK [initandlisten] waiting for connections on port 27017" }
-
-    subject     { grok_match(pattern, value) }
+    let(:message) { "2014-11-03T18:28:32.450-0500 I NETWORK [initandlisten] waiting for connections on port 27017" }
 
     it { should include("timestamp" => "2014-11-03T18:28:32.450-0500") }
 
-    it { should include("severity" => "I") }
+    it do
+      if ecs_compatibility?
+        should include("log" => { 'level' => "I" })
+      else
+        should include("severity" => "I")
+      end
+    end
 
-    it { should include("component" => "NETWORK") }
+    it do
+      if ecs_compatibility?
+        should include("mongodb" => hash_including("component" => "NETWORK"))
+      else
+        should include("component" => "NETWORK")
+      end
+    end
 
-    it { should include("context" => "initandlisten") }
+    it do
+      if ecs_compatibility?
+        should include("mongodb" => hash_including("context" => "initandlisten"))
+      else
+        should include("context" => "initandlisten")
+      end
+    end
 
     it "generates a message field" do
-      expect(subject["message"]).to include("waiting for connections on port 27017")
+      expect(subject["message"]).to eql [ message, "waiting for connections on port 27017" ]
     end
   end
 
   context "parsing a message with a missing component" do
 
-    let(:value) { "2015-02-24T18:17:47.148+0000 F -        [conn11] Got signal: 11 (Segmentation fault)." }
+    let(:message) { "2015-02-24T18:17:47.148+0000 F -        [conn11] Got signal: 11 (Segmentation fault)." }
 
-    subject     { grok_match(pattern, value) }
+    it 'matches' do
+      should include("timestamp" => "2015-02-24T18:17:47.148+0000")
 
-    it { should include("timestamp" => "2015-02-24T18:17:47.148+0000") }
+      if ecs_compatibility?
+        expect( grok_result['mongodb'].keys ).to_not include("component")
+      else
+        should include("component" => "-")
+      end
 
-    it { should include("severity" => "F") }
+      if ecs_compatibility?
+        should include("log" => { 'level' => "F" })
+      else
+        should include("severity" => "F")
+      end
 
-    it { should include("component" => "-") }
-
-    it { should include("context" => "conn11") }
+      if ecs_compatibility?
+        should include("mongodb" => hash_including("context" => "conn11"))
+      else
+        should include("context" => "conn11")
+      end
+    end
 
     it "generates a message field" do
-      expect(subject["message"]).to include("Got signal: 11 (Segmentation fault).")
+      expect(subject["message"]).to eql [ message, "Got signal: 11 (Segmentation fault)." ]
     end
   end
 
   context "parsing a message with a multiwords context" do
 
-    let(:value) { "2015-04-23T06:57:28.256+0200 I JOURNAL  [journal writer] Journal writer thread started" }
+    let(:message) { "2015-04-23T06:57:28.256+0200 I JOURNAL  [journal writer] Journal writer thread started" }
 
-    subject     { grok_match(pattern, value) }
+    it 'matches' do
+      should include("timestamp" => "2015-04-23T06:57:28.256+0200")
 
-    it { should include("timestamp" => "2015-04-23T06:57:28.256+0200") }
+      if ecs_compatibility?
+        should include("log" => { 'level' => "I" })
+      else
+        should include("severity" => "I")
+      end
 
-    it { should include("severity" => "I") }
+      if ecs_compatibility?
+        should include("mongodb" => hash_including("component" => "JOURNAL"))
+      else
+        should include("component" => "JOURNAL")
+      end
 
-    it { should include("component" => "JOURNAL") }
-
-    it { should include("context" => "journal writer") }
+      if ecs_compatibility?
+        should include("mongodb" => hash_including("context" => "journal writer"))
+      else
+        should include("context" => "journal writer")
+      end
+    end
 
     it "generates a message field" do
       expect(subject["message"]).to include("Journal writer thread started")
     end
+
+    context '3.6 simple log line' do
+
+      let(:message) do
+        '2020-08-13T11:58:09.672+0200 I NETWORK  [conn2] end connection 127.0.0.1:41258 (1 connection now open)'
+      end
+
+      it 'matches' do
+        should include("timestamp" => "2020-08-13T11:58:09.672+0200")
+
+        if ecs_compatibility?
+          should include("mongodb" => hash_including("component" => "NETWORK"))
+        else
+          should include("component" => "NETWORK")
+        end
+
+        if ecs_compatibility?
+          should include("mongodb" => hash_including("context" => "conn2"))
+        else
+          should include("context" => "conn2")
+        end
+
+        expect(subject["message"]).to include("end connection 127.0.0.1:41258 (1 connection now open)")
+      end
+
+    end
+
+    context '3.6 long log line' do
+
+      let(:command) do
+        'command config.$cmd command: createIndexes { createIndexes: "system.sessions", ' +
+            'indexes: [ { key: { lastUse: 1 }, name: "lsidTTLIndex", expireAfterSeconds: 1800 } ], $db: "config" } ' +
+            'numYields:0 reslen:101 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, Database: { acquireCount: { w: 2 } }, ' +
+            'Collection: { acquireCount: { w: 1 } } } protocol:op_msg 0ms'
+      end
+
+      let(:message) do
+        '2020-08-13T11:57:45.259+0200 I COMMAND  [LogicalSessionCacheRefresh] ' + command
+      end
+
+      it 'matches' do
+        should include("timestamp" => "2020-08-13T11:57:45.259+0200")
+
+        if ecs_compatibility?
+          should include("mongodb" => hash_including("component" => "COMMAND"))
+        else
+          should include("component" => "COMMAND")
+        end
+
+        if ecs_compatibility?
+          should include("mongodb" => hash_including("context" => "LogicalSessionCacheRefresh"))
+        else
+          should include("context" => "LogicalSessionCacheRefresh")
+        end
+
+        expect(subject["message"]).to eql [message, command]
+      end
+
+    end
+
   end
 
   context "parsing a message without context" do
 
-    let(:value) { "2015-04-23T07:00:13.864+0200 I CONTROL  Ctrl-C signal" }
+    let(:message) { "2015-04-23T07:00:13.864+0200 I CONTROL  Ctrl-C signal" }
 
-    subject     { grok_match(pattern, value) }
+    it 'matches' do
+      should include("timestamp" => "2015-04-23T07:00:13.864+0200")
 
-    it { should include("timestamp" => "2015-04-23T07:00:13.864+0200") }
+      if ecs_compatibility?
+        should include("log" => { 'level' => "I" })
+      else
+        should include("severity" => "I")
+      end
 
-    it { should include("severity" => "I") }
+      if ecs_compatibility?
+        should include("mongodb" => hash_including("component" => "CONTROL"))
+      else
+        should include("component" => "CONTROL")
+      end
 
-    it { should include("component" => "CONTROL") }
-
-    it { should_not have_key("context") }
+      if ecs_compatibility?
+        expect( grok_result['mongodb'].keys ).to_not include("context")
+      else
+        should_not have_key("context")
+      end
+    end
 
     it "generates a message field" do
-      expect(subject["message"]).to include("Ctrl-C signal")
+      expect(subject["message"]).to eql [ message, "Ctrl-C signal" ]
     end
   end
 end
@@ -111,3 +221,10 @@ describe_pattern "MONGO_SLOWQUERY", ['legacy', 'ecs-v1'] do
 end
 
 
+# context 'another log' do
+#
+#   let(:message) do
+#
+#   end
+#
+# end

--- a/spec/patterns/mongodb_spec.rb
+++ b/spec/patterns/mongodb_spec.rb
@@ -83,29 +83,31 @@ describe "MONGO3_LOG" do
   end
 end
 
-describe "MONGO_SLOWQUERY" do
+describe_pattern "MONGO_SLOWQUERY", ['legacy', 'ecs-v1'] do
 
-  let(:pattern) { "MONGO_SLOWQUERY" }
-  let(:value) do
+  let(:message) do
     "[conn11485496] query sample.User query: { clientId: 12345 } ntoreturn:0 ntoskip:0 nscanned:287011 keyUpdates:0 numYields: 2 locks(micros) r:4187700 nreturned:18 reslen:14019 2340ms"
   end
 
-  subject { grok_match(pattern, value) }
-
   it do
-    should include("database" => "sample", "collection" => "User")
-  end
-
-  it do
-    should include("ntoreturn" => '0', "ntoskip" => '0', "nscanned" => "287011", "nreturned" => "18")
-  end
-
-  it do
-    should include("query" => "{ clientId: 12345 }")
-  end
-
-  it do
-    should include("duration" => "2340")
+    if ecs_compatibility?
+      should include("mongodb" => {
+          "database" => "sample", "collection" => "User",
+          "query" => { "original"=>"{ clientId: 12345 }" },
+          "profile" => {
+              "op" => "query",
+              "ntoreturn" => 0, "ntoskip" => 0, "nscanned" => 287011, "nreturned" => 18,
+              "duration" => 2340
+          }
+      })
+    else
+      should include("database" => "sample", "collection" => "User")
+      should include("ntoreturn" => '0', "ntoskip" => '0', "nscanned" => "287011", "nreturned" => "18")
+      should include("query" => "{ clientId: 12345 }")
+      should include("duration" => "2340")
+    end
   end
 
 end
+
+

--- a/spec/patterns/mongodb_spec.rb
+++ b/spec/patterns/mongodb_spec.rb
@@ -82,3 +82,30 @@ describe "MONGO3_LOG" do
     end
   end
 end
+
+describe "MONGO_SLOWQUERY" do
+
+  let(:pattern) { "MONGO_SLOWQUERY" }
+  let(:value) do
+    "[conn11485496] query sample.User query: { clientId: 12345 } ntoreturn:0 ntoskip:0 nscanned:287011 keyUpdates:0 numYields: 2 locks(micros) r:4187700 nreturned:18 reslen:14019 2340ms"
+  end
+
+  subject { grok_match(pattern, value) }
+
+  it do
+    should include("database" => "sample", "collection" => "User")
+  end
+
+  it do
+    should include("ntoreturn" => '0', "ntoskip" => '0', "nscanned" => "287011", "nreturned" => "18")
+  end
+
+  it do
+    should include("query" => "{ clientId: 12345 }")
+  end
+
+  it do
+    should include("duration" => "2340")
+  end
+
+end


### PR DESCRIPTION
`MONGO3_LOG` is straight forward, the (legacy) `MONGO_SLOWQUERY` could use some :eyes: 

DRAFT since this will need specs for the new ECS names.

*HINT: target is **ecs-wip** branch as this should get a **final review when all patterns** are migrated*