### PR TITLE
Feat: make SQUID3 captures ecs compliant

### DIFF
--- a/patterns/ecs-v1/squid
+++ b/patterns/ecs-v1/squid
@@ -1,4 +1,4 @@
 # Pattern squid3
 # Documentation of squid3 logs formats can be found at the following link:
 # http://wiki.squid-cache.org/Features/LogFormat
-SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[event][action]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(%{NOTSPACE:[user][name]}|-)\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s%{NOTSPACE:[squid][response][content_type]}
+SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[event][action]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(?:-|%{NOTSPACE:[user][name]})\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s(?:-|%{NOTSPACE:[squid][response][content_type]})

--- a/patterns/ecs-v1/squid
+++ b/patterns/ecs-v1/squid
@@ -1,4 +1,4 @@
 # Pattern squid3
 # Documentation of squid3 logs formats can be found at the following link:
 # http://wiki.squid-cache.org/Features/LogFormat
-SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[squid][cache_result_code]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][body][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(%{NOTSPACE:[user][name]}|-)\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s%{NOTSPACE:[squid][request][content_type]}
+SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[squid][cache_result_code]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(%{NOTSPACE:[user][name]}|-)\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s%{NOTSPACE:[squid][request][content_type]}

--- a/patterns/ecs-v1/squid
+++ b/patterns/ecs-v1/squid
@@ -1,4 +1,4 @@
 # Pattern squid3
 # Documentation of squid3 logs formats can be found at the following link:
 # http://wiki.squid-cache.org/Features/LogFormat
-SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[event][action]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(%{NOTSPACE:[user][name]}|-)\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s%{NOTSPACE:[squid][request][content_type]}
+SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[event][action]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(%{NOTSPACE:[user][name]}|-)\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s%{NOTSPACE:[squid][response][content_type]}

--- a/patterns/ecs-v1/squid
+++ b/patterns/ecs-v1/squid
@@ -1,4 +1,4 @@
 # Pattern squid3
 # Documentation of squid3 logs formats can be found at the following link:
 # http://wiki.squid-cache.org/Features/LogFormat
-SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:duration}\s%{IP:client_address}\s%{WORD:cache_result}/%{POSINT:status_code}\s%{NUMBER:bytes}\s%{WORD:request_method}\s%{NOTSPACE:url}\s(%{NOTSPACE:user}|-)\s%{WORD:hierarchy_code}/%{IPORHOST:server}\s%{NOTSPACE:content_type}
+SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[squid][cache_result_code]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][body][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(%{NOTSPACE:[user][name]}|-)\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s%{NOTSPACE:[squid][request][content_type]}

--- a/patterns/ecs-v1/squid
+++ b/patterns/ecs-v1/squid
@@ -1,4 +1,4 @@
 # Pattern squid3
 # Documentation of squid3 logs formats can be found at the following link:
 # http://wiki.squid-cache.org/Features/LogFormat
-SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[squid][cache_result_code]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(%{NOTSPACE:[user][name]}|-)\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s%{NOTSPACE:[squid][request][content_type]}
+SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:[squid][request][duration]:int}\s%{IP:[source][ip]}\s%{WORD:[event][action]}/%{POSINT:[http][response][status_code]:int}\s%{INT:[http][response][bytes]:int}\s%{WORD:[http][request][method]}\s%{NOTSPACE:[url][original]}\s(%{NOTSPACE:[user][name]}|-)\s%{WORD:[squid][hierarchy_code]}/%{IPORHOST:[destination][address]}\s%{NOTSPACE:[squid][request][content_type]}

--- a/patterns/legacy/squid
+++ b/patterns/legacy/squid
@@ -1,4 +1,4 @@
 # Pattern squid3
 # Documentation of squid3 logs formats can be found at the following link:
 # http://wiki.squid-cache.org/Features/LogFormat
-SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:duration}\s%{IP:client_address}\s%{WORD:cache_result}/%{POSINT:status_code}\s%{NUMBER:bytes}\s%{WORD:request_method}\s%{NOTSPACE:url}\s(%{NOTSPACE:user}|-)\s%{WORD:hierarchy_code}/%{IPORHOST:server}\s%{NOTSPACE:content_type}
+SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:duration}\s%{IP:client_address}\s%{WORD:cache_result}/%{POSINT:status_code}\s%{NUMBER:bytes}\s%{WORD:request_method}\s%{NOTSPACE:url}\s(%{NOTSPACE:user})\s%{WORD:hierarchy_code}/%{IPORHOST:server}\s%{NOTSPACE:content_type}

--- a/patterns/legacy/squid
+++ b/patterns/legacy/squid
@@ -1,4 +1,4 @@
 # Pattern squid3
 # Documentation of squid3 logs formats can be found at the following link:
 # http://wiki.squid-cache.org/Features/LogFormat
-SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:duration}\s%{IP:client_address}\s%{WORD:cache_result}/%{POSINT:status_code}\s%{NUMBER:bytes}\s%{WORD:request_method}\s%{NOTSPACE:url}\s(%{NOTSPACE:user})\s%{WORD:hierarchy_code}/%{IPORHOST:server}\s%{NOTSPACE:content_type}
+SQUID3 %{NUMBER:timestamp}\s+%{NUMBER:duration}\s%{IP:client_address}\s%{WORD:cache_result}/%{POSINT:status_code}\s%{NUMBER:bytes}\s%{WORD:request_method}\s%{NOTSPACE:url}\s(%{NOTSPACE:user}|-)\s%{WORD:hierarchy_code}/%{IPORHOST:server}\s%{NOTSPACE:content_type}

--- a/spec/patterns/squid_spec.rb
+++ b/spec/patterns/squid_spec.rb
@@ -2,60 +2,84 @@
 require "spec_helper"
 require "logstash/patterns/core"
 
-describe "SQUID3" do
-
-  let(:grok) { grok_match("SQUID3", value) }
+describe_pattern "SQUID3", ['legacy', 'ecs-v1'] do
 
   describe 'CONNECT sample' do
 
-    let(:value) do
+    let(:message) do
       '1525344856.899  16867 10.170.72.111 TCP_TUNNEL/200 6256 CONNECT logs.ap-southeast-2.amazonaws.com:443 - HIER_DIRECT/53.140.206.134 -'
     end
 
     it "matches" do
-      expect(grok).to include(
-                          "timestamp" => "1525344856.899",
-                          "duration" => "16867",
-                          "client_address" => "10.170.72.111",
-                          "cache_result" => "TCP_TUNNEL",
-                          "status_code" => "200",
-                          "request_method" => "CONNECT",
-                          "bytes" => "6256",
-                          "url" => "logs.ap-southeast-2.amazonaws.com:443",
-                          "user" => "-",
-                          "hierarchy_code" => "HIER_DIRECT",
-                          "server" => "53.140.206.134",
-                          "content_type" => "-",
-                      )
+      expect(grok).to include("timestamp" => "1525344856.899")
+      if ecs_compatibility?
+        expect(grok).to include(
+                            "squid" => {
+                                "cache_result_code" => "TCP_TUNNEL",
+                                "hierarchy_code" => "HIER_DIRECT",
+                                "request" => { "duration" => 16867, "content_type" => "-" }
+                            })
+        expect(grok).to include("destination" => { "address" => "53.140.206.134" })
+        expect(grok).to include("http" => { "request" => { "method" => "CONNECT" }, "response" => { "bytes" => 6256, "status_code" => 200 } })
+        expect(grok).to include("url" => { "original" => "logs.ap-southeast-2.amazonaws.com:443" })
+        expect(grok).to include("source" => { "ip" => "10.170.72.111" })
+      else
+        expect(grok).to include(
+                            "duration" => "16867",
+                            "client_address" => "10.170.72.111",
+                            "cache_result" => "TCP_TUNNEL",
+                            "status_code" => "200",
+                            "request_method" => "CONNECT",
+                            "bytes" => "6256",
+                            "url" => "logs.ap-southeast-2.amazonaws.com:443",
+                            "user" => "-",
+                            "hierarchy_code" => "HIER_DIRECT",
+                            "server" => "53.140.206.134",
+                            "content_type" => "-",
+                            )
+      end
     end
 
   end
 
   describe 'GET sample' do
 
-    let(:value) do
+    let(:message) do
       "1525334330.556      3 120.65.1.1 TCP_REFRESH_MISS/200 2014 GET http://www.sample.com/hellow_world.txt public-user DIRECT/www.sample.com text/plain 902351708.872"
     end
 
     it "matches" do
-      expect(grok).to include(
-                          "timestamp"=>"1525334330.556",
-                          "duration"=>"3",
-                          "client_address"=>"120.65.1.1",
-                          "cache_result"=>"TCP_REFRESH_MISS",
-                          "status_code"=>"200",
-                          "bytes"=>"2014",
-                          "request_method" => "GET",
-                          "url" => "http://www.sample.com/hellow_world.txt",
-                          "user"=>"public-user",
-                          "hierarchy_code"=>"DIRECT",
-                          "server"=>"www.sample.com",
-                          "content_type"=>"text/plain",
-                      )
+      expect(grok).to include("timestamp" => "1525334330.556")
+      if ecs_compatibility?
+        expect(grok).to include(
+                            "squid" => {
+                                "cache_result_code" => "TCP_REFRESH_MISS",
+                                "request" => { "content_type" => "text/plain", "duration" => 3 }, "hierarchy_code" => "DIRECT"
+                            })
+        expect(grok).to include("destination" => { "address" => "www.sample.com" })
+        expect(grok).to include("http" => { "request" => { "method" => "GET" }, "response" => { "bytes" => 2014, "status_code" => 200 } })
+        expect(grok).to include("url" => { "original" => "http://www.sample.com/hellow_world.txt" })
+        expect(grok).to include("source" => { "ip" => "120.65.1.1" })
+        expect(grok).to include("user" => { "name" => "public-user" })
+      else
+        expect(grok).to include(
+                            "duration"=>"3",
+                            "client_address"=>"120.65.1.1",
+                            "cache_result"=>"TCP_REFRESH_MISS",
+                            "status_code"=>"200",
+                            "bytes"=>"2014",
+                            "request_method" => "GET",
+                            "url" => "http://www.sample.com/hellow_world.txt",
+                            "user"=>"public-user",
+                            "hierarchy_code"=>"DIRECT",
+                            "server"=>"www.sample.com",
+                            "content_type"=>"text/plain",
+                            )
+      end
     end
 
     it "retains message" do
-      expect(grok).to include("message" => value)
+      expect(grok).to include("message" => message)
     end
 
   end

--- a/spec/patterns/squid_spec.rb
+++ b/spec/patterns/squid_spec.rb
@@ -14,8 +14,8 @@ describe_pattern "SQUID3", ['legacy', 'ecs-v1'] do
       expect(grok).to include("timestamp" => "1525344856.899")
       if ecs_compatibility?
         expect(grok).to include(
+                            "event" => { "action" => "TCP_TUNNEL" },
                             "squid" => {
-                                "cache_result_code" => "TCP_TUNNEL",
                                 "hierarchy_code" => "HIER_DIRECT",
                                 "request" => { "duration" => 16867, "content_type" => "-" }
                             })
@@ -52,8 +52,8 @@ describe_pattern "SQUID3", ['legacy', 'ecs-v1'] do
       expect(grok).to include("timestamp" => "1525334330.556")
       if ecs_compatibility?
         expect(grok).to include(
+                            "event" => { "action" => "TCP_REFRESH_MISS" },
                             "squid" => {
-                                "cache_result_code" => "TCP_REFRESH_MISS",
                                 "request" => { "content_type" => "text/plain", "duration" => 3 }, "hierarchy_code" => "DIRECT"
                             })
         expect(grok).to include("destination" => { "address" => "www.sample.com" })

--- a/spec/patterns/squid_spec.rb
+++ b/spec/patterns/squid_spec.rb
@@ -1,0 +1,63 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/patterns/core"
+
+describe "SQUID3" do
+
+  let(:grok) { grok_match("SQUID3", value) }
+
+  describe 'CONNECT sample' do
+
+    let(:value) do
+      '1525344856.899  16867 10.170.72.111 TCP_TUNNEL/200 6256 CONNECT logs.ap-southeast-2.amazonaws.com:443 - HIER_DIRECT/53.140.206.134 -'
+    end
+
+    it "matches" do
+      expect(grok).to include(
+                          "timestamp" => "1525344856.899",
+                          "duration" => "16867",
+                          "client_address" => "10.170.72.111",
+                          "cache_result" => "TCP_TUNNEL",
+                          "status_code" => "200",
+                          "request_method" => "CONNECT",
+                          "bytes" => "6256",
+                          "url" => "logs.ap-southeast-2.amazonaws.com:443",
+                          "user" => "-",
+                          "hierarchy_code" => "HIER_DIRECT",
+                          "server" => "53.140.206.134",
+                          "content_type" => "-",
+                      )
+    end
+
+  end
+
+  describe 'GET sample' do
+
+    let(:value) do
+      "1525334330.556      3 120.65.1.1 TCP_REFRESH_MISS/200 2014 GET http://www.sample.com/hellow_world.txt public-user DIRECT/www.sample.com text/plain 902351708.872"
+    end
+
+    it "matches" do
+      expect(grok).to include(
+                          "timestamp"=>"1525334330.556",
+                          "duration"=>"3",
+                          "client_address"=>"120.65.1.1",
+                          "cache_result"=>"TCP_REFRESH_MISS",
+                          "status_code"=>"200",
+                          "bytes"=>"2014",
+                          "request_method" => "GET",
+                          "url" => "http://www.sample.com/hellow_world.txt",
+                          "user"=>"public-user",
+                          "hierarchy_code"=>"DIRECT",
+                          "server"=>"www.sample.com",
+                          "content_type"=>"text/plain",
+                      )
+    end
+
+    it "retains message" do
+      expect(grok).to include("message" => value)
+    end
+
+  end
+
+end

--- a/spec/patterns/squid_spec.rb
+++ b/spec/patterns/squid_spec.rb
@@ -17,7 +17,6 @@ describe_pattern "SQUID3", ['legacy', 'ecs-v1'] do
                             "event" => { "action" => "TCP_TUNNEL" },
                             "squid" => {
                                 "request" => { "duration" => 16867 },
-                                "response" => { "content_type" => "-" },
                                 "hierarchy_code" => "HIER_DIRECT"
                             })
         expect(grok).to include("destination" => { "address" => "53.140.206.134" })
@@ -38,6 +37,18 @@ describe_pattern "SQUID3", ['legacy', 'ecs-v1'] do
                             "server" => "53.140.206.134",
                             "content_type" => "-",
                             )
+      end
+    end
+
+    it "does not include missing ('-') user-name" do
+      if ecs_compatibility?
+        expect(grok.keys).to_not include("user") # "user" => { "name" => "-" }
+      end
+    end
+
+    it "does not include missing ('-') content-type" do
+      if ecs_compatibility?
+        expect(grok['squid'].keys).to_not include("response") # "squid" => { "response" => { "content_type" => "-" } }
       end
     end
 

--- a/spec/patterns/squid_spec.rb
+++ b/spec/patterns/squid_spec.rb
@@ -16,8 +16,9 @@ describe_pattern "SQUID3", ['legacy', 'ecs-v1'] do
         expect(grok).to include(
                             "event" => { "action" => "TCP_TUNNEL" },
                             "squid" => {
-                                "hierarchy_code" => "HIER_DIRECT",
-                                "request" => { "duration" => 16867, "content_type" => "-" }
+                                "request" => { "duration" => 16867 },
+                                "response" => { "content_type" => "-" },
+                                "hierarchy_code" => "HIER_DIRECT"
                             })
         expect(grok).to include("destination" => { "address" => "53.140.206.134" })
         expect(grok).to include("http" => { "request" => { "method" => "CONNECT" }, "response" => { "bytes" => 6256, "status_code" => 200 } })
@@ -54,7 +55,9 @@ describe_pattern "SQUID3", ['legacy', 'ecs-v1'] do
         expect(grok).to include(
                             "event" => { "action" => "TCP_REFRESH_MISS" },
                             "squid" => {
-                                "request" => { "content_type" => "text/plain", "duration" => 3 }, "hierarchy_code" => "DIRECT"
+                                "request" => { "duration" => 3 },
+                                "response" => { "content_type" => "text/plain" },
+                                "hierarchy_code" => "DIRECT"
                             })
         expect(grok).to include("destination" => { "address" => "www.sample.com" })
         expect(grok).to include("http" => { "request" => { "method" => "GET" }, "response" => { "bytes" => 2014, "status_code" => 200 } })


### PR DESCRIPTION
`"1525334330.556      3 120.65.1.1 TCP_REFRESH_MISS/200 2014 GET http://www.sample.com/hellow_world.txt public-user DIRECT/www.sample.com text/plain 902351708.872"`

matching **before** and **after**:
```
      "timestamp"=>"1525334330.556",
      "duration"=>"3",
      "client_address"=>"120.65.1.1",
      "cache_result"=>"TCP_REFRESH_MISS",
      "status_code"=>"200",
      "bytes"=>"2014",
      "request_method" => "GET",
      "url" => "http://www.sample.com/hellow_world.txt",
      "user"=>"public-user",
      "hierarchy_code"=>"DIRECT",
      "server"=>"www.sample.com",
      "content_type"=>"text/plain",
```
```
      "timestamp"=>"1525334330.556",
      "source"=>{"ip"=>"120.65.1.1"},
      "http"=>{
          "request"=>{"method"=>"GET"},
          "response"=>{"status_code"=>200, "body"=>{"bytes"=>2014}}
      },
      "destination"=>{"address"=>"www.sample.com"},
      "url"=>{"original"=>"http://www.sample.com/hellow_world.txt"},
      "user"=>{"name"=>"public-user",
      "squid"=>{
          "request"=>{"duration"=>3, "content_type"=>"text/plain"},
          "hierarchy_code"=>"DIRECT",
          "cache_result_code"=>"TCP_REFRESH_MISS"
      }
```