### PR TITLE
Feat: ecs-ize MCOLLECTIVE named captures

### DIFF
--- a/patterns/ecs-v1/mcollective
+++ b/patterns/ecs-v1/mcollective
@@ -1,1 +1,4 @@
+# Remember, these can be multi-line events.
+MCOLLECTIVE ., \[%{TIMESTAMP_ISO8601:timestamp} #%{POSINT:pid}\]%{SPACE}%{LOGLEVEL:event_level}
+
 MCOLLECTIVEAUDIT %{TIMESTAMP_ISO8601:timestamp}:

--- a/patterns/ecs-v1/mcollective
+++ b/patterns/ecs-v1/mcollective
@@ -1,4 +1,4 @@
 # Remember, these can be multi-line events.
-MCOLLECTIVE ., \[%{TIMESTAMP_ISO8601:timestamp} #%{POSINT:pid}\]%{SPACE}%{LOGLEVEL:event_level}
+MCOLLECTIVE ., \[%{TIMESTAMP_ISO8601:timestamp} #%{POSINT:[process][pid]:int}\]%{SPACE}%{LOGLEVEL:[log][level]}
 
 MCOLLECTIVEAUDIT %{TIMESTAMP_ISO8601:timestamp}:

--- a/patterns/ecs-v1/mcollective-patterns
+++ b/patterns/ecs-v1/mcollective-patterns
@@ -1,4 +1,0 @@
-# Remember, these can be multi-line events.
-MCOLLECTIVE ., \[%{TIMESTAMP_ISO8601:timestamp} #%{POSINT:pid}\]%{SPACE}%{LOGLEVEL:event_level}
-
-MCOLLECTIVEAUDIT %{TIMESTAMP_ISO8601:timestamp}:

--- a/spec/patterns/mcollective_spec.rb
+++ b/spec/patterns/mcollective_spec.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/patterns/core"
+
+describe "MCOLLECTIVE" do
+
+  let(:pattern) { "MCOLLECTIVE" }
+  let(:value) { "I, [2010-12-29T11:15:32.321744 #11479]  INFO -- : mcollectived:33 The Marionette Collective 1.1.0 started logging at info level" }
+
+  subject { grok_match(pattern, value) }
+
+  it { should include("timestamp"=>"2010-12-29T11:15:32.321744") }
+  it { should include("pid"=>"11479") }
+  it { should include("event_level"=>"INFO") }
+
+  # NOTE: pattern seems unfinished - missing match of remaining message
+  it 'should have extracted message' do
+    # but did not :
+    expect( subject['message'] ).to eql value
+  end
+
+end

--- a/spec/patterns/mcollective_spec.rb
+++ b/spec/patterns/mcollective_spec.rb
@@ -2,21 +2,34 @@
 require "spec_helper"
 require "logstash/patterns/core"
 
-describe "MCOLLECTIVE" do
+describe_pattern "MCOLLECTIVE" do
 
-  let(:pattern) { "MCOLLECTIVE" }
-  let(:value) { "I, [2010-12-29T11:15:32.321744 #11479]  INFO -- : mcollectived:33 The Marionette Collective 1.1.0 started logging at info level" }
+  let(:message) { "I, [2010-12-29T11:15:32.321744 #11479]  INFO -- : mcollectived:33 The Marionette Collective 1.1.0 started logging at info level" }
 
-  subject { grok_match(pattern, value) }
+  it do
+    should include("timestamp" => "2010-12-29T11:15:32.321744")
+  end
 
-  it { should include("timestamp"=>"2010-12-29T11:15:32.321744") }
-  it { should include("pid"=>"11479") }
-  it { should include("event_level"=>"INFO") }
+  it do
+    if ecs_compatibility?
+      should include("process" => { "pid" => 11479 })
+    else
+      should include("pid" => "11479")
+    end
+  end
+
+  it do
+    if ecs_compatibility?
+      should include("log" => hash_including("level" => "INFO"))
+    else
+      should include("event_level" => "INFO")
+    end
+  end
 
   # NOTE: pattern seems unfinished - missing match of remaining message
   it 'should have extracted message' do
     # but did not :
-    expect( subject['message'] ).to eql value
+    expect( subject['message'] ).to eql message
   end
 
 end


### PR DESCRIPTION
NOTE: MCollective is deprecated these days and (as the new spec indicates) matching seems to not have been complete.

*HINT: target is **ecs-wip** branch as this should get a **final review when all patterns** are migrated*