### PR TITLE
Fix: Java stack trace's JAVAFILE to better match generated names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.2.0
+  - Fix: Java stack trace's JAVAFILE to better match generated names 
+
 ## 4.1.2
   - Fix some documentation issues
 

--- a/logstash-patterns-core.gemspec
+++ b/logstash-patterns-core.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-patterns-core'
-  s.version         = '4.1.2'
+  s.version         = '4.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Patterns to be used in logstash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/patterns/java
+++ b/patterns/java
@@ -1,6 +1,6 @@
 JAVACLASS (?:[a-zA-Z$_][a-zA-Z$_0-9]*\.)*[a-zA-Z$_][a-zA-Z$_0-9]*
 #Space is an allowed character to match special cases like 'Native Method' or 'Unknown Source'
-JAVAFILE (?:[A-Za-z0-9_. -]+)
+JAVAFILE (?:[a-zA-Z$_0-9. -]+)
 #Allow special <init>, <clinit> methods
 JAVAMETHOD (?:(<(?:cl)?init>)|[a-zA-Z$_][a-zA-Z$_0-9]*)
 #Line number is optional in special cases 'Native method' or 'Unknown source'

--- a/spec/patterns/java_spec.rb
+++ b/spec/patterns/java_spec.rb
@@ -16,3 +16,31 @@ describe "JAVA" do
     end
   end
 end
+
+describe "JAVASTACKTRACEPART" do
+  let(:pattern) { 'JAVASTACKTRACEPART' }
+  let(:message) { '  at com.sample.stacktrace.StackTraceExample.aMethod(StackTraceExample.java:42)' }
+  it "matches" do
+    grok = grok_match(pattern, message, true)
+    expect(grok).to include({
+                                "message"=>"  at com.sample.stacktrace.StackTraceExample.aMethod(StackTraceExample.java:42)",
+                                "method"=>"aMethod",
+                                "class"=>"com.sample.stacktrace.StackTraceExample",
+                                "file"=>"StackTraceExample.java",
+                                "line"=>"42"
+                            })
+  end
+
+  context 'generated file' do
+    let(:message) { '  at org.jruby.RubyMethod$INVOKER$i$call.call(RubyMethod$INVOKER$i$call.gen)' }
+    it "matches" do
+      grok = grok_match(pattern, message, true)
+      # TODO does not match
+      # expect(grok).to include({
+      #                             "method"=>"call",
+      #                             "class"=>"org.jruby.RubyMethod$INVOKER$i$call",
+      #                             "file"=>"RubyMethod$INVOKER$i$call.gen",
+      #                         })
+    end
+  end
+end

--- a/spec/patterns/java_spec.rb
+++ b/spec/patterns/java_spec.rb
@@ -35,12 +35,11 @@ describe "JAVASTACKTRACEPART" do
     let(:message) { '  at org.jruby.RubyMethod$INVOKER$i$call.call(RubyMethod$INVOKER$i$call.gen)' }
     it "matches" do
       grok = grok_match(pattern, message, true)
-      # TODO does not match
-      # expect(grok).to include({
-      #                             "method"=>"call",
-      #                             "class"=>"org.jruby.RubyMethod$INVOKER$i$call",
-      #                             "file"=>"RubyMethod$INVOKER$i$call.gen",
-      #                         })
+      expect(grok).to include({
+                                  "method"=>"call",
+                                  "class"=>"org.jruby.RubyMethod$INVOKER$i$call",
+                                  "file"=>"RubyMethod$INVOKER$i$call.gen",
+                              })
     end
   end
 end


### PR DESCRIPTION
As the specs demonstrates `JAVAFILE` wasn't matching `RubyMethod$INVOKER$i$call.gen`.

Context: we'll be adding some missing PATTERN specs for ECS and leaving a `TODO` for discovered 'broken' behavior (to be handled later) is confusing reviewers thus I decided to target some minor (potentially breaking) changes for **4.2.0** on their own.

... to be continued
