### PR TITLE
Fix: match Information/INFORMATION in LOGLEVEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.2.0
-  - Fix: Java stack trace's JAVAFILE to better match generated names 
+  - Fix: Java stack trace's JAVAFILE to better match generated names
+  - Fix: match Information/INFORMATION in LOGLEVEL [#274](https://github.com/logstash-plugins/logstash-patterns-core/pull/274) 
 
 ## 4.1.2
   - Fix some documentation issues

--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -92,4 +92,4 @@ QS %{QUOTEDSTRING}
 SYSLOGBASE %{SYSLOGTIMESTAMP:timestamp} (?:%{SYSLOGFACILITY} )?%{SYSLOGHOST:logsource} %{SYSLOGPROG}:
 
 # Log Levels
-LOGLEVEL ([Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|[Nn]otice|NOTICE|[Ii]nfo|INFO|[Ww]arn?(?:ing)?|WARN?(?:ING)?|[Ee]rr?(?:or)?|ERR?(?:OR)?|[Cc]rit?(?:ical)?|CRIT?(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)
+LOGLEVEL ([Aa]lert|ALERT|[Tt]race|TRACE|[Dd]ebug|DEBUG|[Nn]otice|NOTICE|[Ii]nfo?(?:rmation)?|INFO?(?:RMATION)?|[Ww]arn?(?:ing)?|WARN?(?:ING)?|[Ee]rr?(?:or)?|ERR?(?:OR)?|[Cc]rit?(?:ical)?|CRIT?(?:ICAL)?|[Ff]atal|FATAL|[Ss]evere|SEVERE|EMERG(?:ENCY)?|[Ee]merg(?:ency)?)

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -63,6 +63,19 @@ describe "TOMCATLOG" do
   end
 end
 
+describe 'LOGLEVEL' do
+  it 'matches info label' do
+    expect(grok_match(subject, 'INFO')).to pass
+    expect(grok_match(subject, 'info')).to pass
+  end
+
+  it 'matches information label' do
+    expect(grok_match(subject, 'information')).to pass
+    expect(grok_match(subject, 'Information')).to pass
+    expect(grok_match(subject, 'INFORMATION')).to pass
+  end
+end
+
 describe "IPORHOST" do
 
   let(:pattern)    { "IPORHOST" }


### PR DESCRIPTION
Reviewing existing PRs before the ECS split - this one was attempted several times.

origin #205
