### PR TITLE
Fix: NAGIOS TIMEPERIOD unknown (from/to) field matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.2.0
   - Fix: Java stack trace's JAVAFILE to better match generated names
-  - Fix: match Information/INFORMATION in LOGLEVEL [#274](https://github.com/logstash-plugins/logstash-patterns-core/pull/274) 
+  - Fix: match Information/INFORMATION in LOGLEVEL [#274](https://github.com/logstash-plugins/logstash-patterns-core/pull/274)
+  - Fix: NAGIOS TIMEPERIOD unknown (from/to) field matching [#275](https://github.com/logstash-plugins/logstash-patterns-core/pull/275) 
 
 ## 4.1.2
   - Fix some documentation issues

--- a/patterns/nagios
+++ b/patterns/nagios
@@ -89,7 +89,7 @@ NAGIOS_PASSIVE_HOST_CHECK %{NAGIOS_TYPE_PASSIVE_HOST_CHECK:nagios_type}: %{DATA:
 NAGIOS_SERVICE_EVENT_HANDLER %{NAGIOS_TYPE_SERVICE_EVENT_HANDLER:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{DATA:nagios_statelevel};%{DATA:nagios_event_handler_name}
 NAGIOS_HOST_EVENT_HANDLER %{NAGIOS_TYPE_HOST_EVENT_HANDLER:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_state};%{DATA:nagios_statelevel};%{DATA:nagios_event_handler_name}
 
-NAGIOS_TIMEPERIOD_TRANSITION %{NAGIOS_TYPE_TIMEPERIOD_TRANSITION:nagios_type}: %{DATA:nagios_service};%{DATA:nagios_unknown1};%{DATA:nagios_unknown2}
+NAGIOS_TIMEPERIOD_TRANSITION %{NAGIOS_TYPE_TIMEPERIOD_TRANSITION:nagios_type}: %{DATA:nagios_service};%{NUMBER:nagios_unknown1};%{NUMBER:nagios_unknown2}
 
 ####################
 #### External checks

--- a/spec/patterns/nagios_spec.rb
+++ b/spec/patterns/nagios_spec.rb
@@ -82,7 +82,7 @@ end
 
 describe "NAGIOSLOGLINE - TIMEPERIOD TRANSITION" do
 
-  let(:value)   { "[1427925600] TIMEPERIOD TRANSITION: 24X7;1;1" }
+  let(:value)   { "[1427925600] TIMEPERIOD TRANSITION: 24X7;-1;1" }
   let(:grok)    { grok_match(subject, value) }
 
   it "a pattern pass the grok expression" do
@@ -103,6 +103,10 @@ describe "NAGIOSLOGLINE - TIMEPERIOD TRANSITION" do
 
   it "generates the nagios_esrvice field" do
     expect(grok).to include("nagios_service" => "24X7")
+  end
+
+  it "generates the period from/to fields" do
+    expect(grok).to include("nagios_unknown1" => "-1", "nagios_unknown2" => "1")
   end
 
   # Regression test for but fixed in Nagios patterns #30


### PR DESCRIPTION
## Why?

The `NAGIOSLOGLINE` failed to properly capture a `TIMEPERIOD TRANSITION: 24x7;-1;1` log line.

## Description
The (from/to) fields in the pattern are (due legacy reasons) named `nagios_unknown`.

a lot of potential numeric (integer) values within `NAGIOSLOGLINE` are matched simply as `DATA`,
usually not an issue except in this case where the "unknown" field is set to `-1` (to indicate a null value),
as (I am guessing) they're using the defined time-periods (such as *us_holidays* or *24x7*).

the 'not-set' value `-1` for the first field is quite common and breaks matching (due `-`).

*OT: still struggling to find a meaningful sample where these are filled with smt else than `-1;0` or `-1;1`*
