### PR TITLE
Feat: make NAGIOSLOGLINE captures ECS compliant

### DIFF
--- a/patterns/ecs-v1/nagios
+++ b/patterns/ecs-v1/nagios
@@ -14,7 +14,7 @@
 #################################################################################
 #################################################################################
 
-NAGIOSTIME \[%{NUMBER:nagios_epoch}\]
+NAGIOSTIME \[%{NUMBER:timestamp}\]
 
 ###############################################
 ######## Begin nagios log types
@@ -66,59 +66,59 @@ NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS ENABLE_SVC_NOTIFICATIONS
 ###############################################
 ######## End external check types
 ###############################################
-NAGIOS_WARNING Warning:%{SPACE}%{GREEDYDATA:nagios_message}
+NAGIOS_WARNING Warning:%{SPACE}%{GREEDYDATA:message}
 
-NAGIOS_CURRENT_SERVICE_STATE %{NAGIOS_TYPE_CURRENT_SERVICE_STATE:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{DATA:nagios_statetype};%{DATA:nagios_statecode};%{GREEDYDATA:nagios_message}
-NAGIOS_CURRENT_HOST_STATE %{NAGIOS_TYPE_CURRENT_HOST_STATE:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_state};%{DATA:nagios_statetype};%{DATA:nagios_statecode};%{GREEDYDATA:nagios_message}
+NAGIOS_CURRENT_SERVICE_STATE %{NAGIOS_TYPE_CURRENT_SERVICE_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
+NAGIOS_CURRENT_HOST_STATE %{NAGIOS_TYPE_CURRENT_HOST_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_NOTIFICATION %{NAGIOS_TYPE_SERVICE_NOTIFICATION:nagios_type}: %{DATA:nagios_notifyname};%{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{DATA:nagios_contact};%{GREEDYDATA:nagios_message}
-NAGIOS_HOST_NOTIFICATION %{NAGIOS_TYPE_HOST_NOTIFICATION:nagios_type}: %{DATA:nagios_notifyname};%{DATA:nagios_hostname};%{DATA:nagios_state};%{DATA:nagios_contact};%{GREEDYDATA:nagios_message}
+NAGIOS_SERVICE_NOTIFICATION %{NAGIOS_TYPE_SERVICE_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
+NAGIOS_HOST_NOTIFICATION %{NAGIOS_TYPE_HOST_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_ALERT %{NAGIOS_TYPE_SERVICE_ALERT:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{DATA:nagios_statelevel};%{NUMBER:nagios_attempt};%{GREEDYDATA:nagios_message}
-NAGIOS_HOST_ALERT %{NAGIOS_TYPE_HOST_ALERT:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_state};%{DATA:nagios_statelevel};%{NUMBER:nagios_attempt};%{GREEDYDATA:nagios_message}
+NAGIOS_SERVICE_ALERT %{NAGIOS_TYPE_SERVICE_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
+NAGIOS_HOST_ALERT %{NAGIOS_TYPE_HOST_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_FLAPPING_ALERT %{NAGIOS_TYPE_SERVICE_FLAPPING_ALERT:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{GREEDYDATA:nagios_message}
-NAGIOS_HOST_FLAPPING_ALERT %{NAGIOS_TYPE_HOST_FLAPPING_ALERT:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_state};%{GREEDYDATA:nagios_message}
+NAGIOS_SERVICE_FLAPPING_ALERT %{NAGIOS_TYPE_SERVICE_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{GREEDYDATA:message}
+NAGIOS_HOST_FLAPPING_ALERT %{NAGIOS_TYPE_HOST_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_DOWNTIME_ALERT %{NAGIOS_TYPE_SERVICE_DOWNTIME_ALERT:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{GREEDYDATA:nagios_comment}
-NAGIOS_HOST_DOWNTIME_ALERT %{NAGIOS_TYPE_HOST_DOWNTIME_ALERT:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_state};%{GREEDYDATA:nagios_comment}
+NAGIOS_SERVICE_DOWNTIME_ALERT %{NAGIOS_TYPE_SERVICE_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
+NAGIOS_HOST_DOWNTIME_ALERT %{NAGIOS_TYPE_HOST_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
 
-NAGIOS_PASSIVE_SERVICE_CHECK %{NAGIOS_TYPE_PASSIVE_SERVICE_CHECK:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{GREEDYDATA:nagios_comment}
-NAGIOS_PASSIVE_HOST_CHECK %{NAGIOS_TYPE_PASSIVE_HOST_CHECK:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_state};%{GREEDYDATA:nagios_comment}
+NAGIOS_PASSIVE_SERVICE_CHECK %{NAGIOS_TYPE_PASSIVE_SERVICE_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
+NAGIOS_PASSIVE_HOST_CHECK %{NAGIOS_TYPE_PASSIVE_HOST_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
 
-NAGIOS_SERVICE_EVENT_HANDLER %{NAGIOS_TYPE_SERVICE_EVENT_HANDLER:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{DATA:nagios_statelevel};%{DATA:nagios_event_handler_name}
-NAGIOS_HOST_EVENT_HANDLER %{NAGIOS_TYPE_HOST_EVENT_HANDLER:nagios_type}: %{DATA:nagios_hostname};%{DATA:nagios_state};%{DATA:nagios_statelevel};%{DATA:nagios_event_handler_name}
+NAGIOS_SERVICE_EVENT_HANDLER %{NAGIOS_TYPE_SERVICE_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
+NAGIOS_HOST_EVENT_HANDLER %{NAGIOS_TYPE_HOST_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
 
-NAGIOS_TIMEPERIOD_TRANSITION %{NAGIOS_TYPE_TIMEPERIOD_TRANSITION:nagios_type}: %{DATA:nagios_service};%{NUMBER:nagios_unknown1};%{NUMBER:nagios_unknown2}
+NAGIOS_TIMEPERIOD_TRANSITION %{NAGIOS_TYPE_TIMEPERIOD_TRANSITION:[nagios][log][type]}: %{DATA:[nagios][log][service]};%{NUMBER:[nagios][log][period_from]:int};%{NUMBER:[nagios][log][period_to]:int}
 
 ####################
 #### External checks
 ####################
 
 #Disable host & service check
-NAGIOS_EC_LINE_DISABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_DISABLE_SVC_CHECK:nagios_command};%{DATA:nagios_hostname};%{DATA:nagios_service}
-NAGIOS_EC_LINE_DISABLE_HOST_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_DISABLE_HOST_CHECK:nagios_command};%{DATA:nagios_hostname}
+NAGIOS_EC_LINE_DISABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_SVC_CHECK:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][service]}
+NAGIOS_EC_LINE_DISABLE_HOST_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_HOST_CHECK:[nagios][log][command]};%{DATA:[host][hostname]}
 
 #Enable host & service check
-NAGIOS_EC_LINE_ENABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_ENABLE_SVC_CHECK:nagios_command};%{DATA:nagios_hostname};%{DATA:nagios_service}
-NAGIOS_EC_LINE_ENABLE_HOST_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_ENABLE_HOST_CHECK:nagios_command};%{DATA:nagios_hostname}
+NAGIOS_EC_LINE_ENABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_SVC_CHECK:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][service]}
+NAGIOS_EC_LINE_ENABLE_HOST_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_HOST_CHECK:[nagios][log][command]};%{DATA:[host][hostname]}
 
 #Process host & service check
-NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_PROCESS_SERVICE_CHECK_RESULT:nagios_command};%{DATA:nagios_hostname};%{DATA:nagios_service};%{DATA:nagios_state};%{GREEDYDATA:nagios_check_result}
-NAGIOS_EC_LINE_PROCESS_HOST_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_PROCESS_HOST_CHECK_RESULT:nagios_command};%{DATA:nagios_hostname};%{DATA:nagios_state};%{GREEDYDATA:nagios_check_result}
+NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_SERVICE_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][check_result]}
+NAGIOS_EC_LINE_PROCESS_HOST_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_HOST_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][check_result]}
 
 #Disable host & service notifications
-NAGIOS_EC_LINE_DISABLE_HOST_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_DISABLE_HOST_SVC_NOTIFICATIONS:nagios_command};%{GREEDYDATA:nagios_hostname}
-NAGIOS_EC_LINE_DISABLE_HOST_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_DISABLE_HOST_NOTIFICATIONS:nagios_command};%{GREEDYDATA:nagios_hostname}
-NAGIOS_EC_LINE_DISABLE_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_DISABLE_SVC_NOTIFICATIONS:nagios_command};%{DATA:nagios_hostname};%{GREEDYDATA:nagios_service}
+NAGIOS_EC_LINE_DISABLE_HOST_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_HOST_SVC_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}
+NAGIOS_EC_LINE_DISABLE_HOST_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_HOST_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}
+NAGIOS_EC_LINE_DISABLE_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_SVC_NOTIFICATIONS:[nagios][log][command]};%{DATA:[host][hostname]};%{GREEDYDATA:[nagios][log][service]}
 
 #Enable host & service notifications
-NAGIOS_EC_LINE_ENABLE_HOST_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_ENABLE_HOST_SVC_NOTIFICATIONS:nagios_command};%{GREEDYDATA:nagios_hostname}
-NAGIOS_EC_LINE_ENABLE_HOST_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_ENABLE_HOST_NOTIFICATIONS:nagios_command};%{GREEDYDATA:nagios_hostname}
-NAGIOS_EC_LINE_ENABLE_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS:nagios_command};%{DATA:nagios_hostname};%{GREEDYDATA:nagios_service}
+NAGIOS_EC_LINE_ENABLE_HOST_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_HOST_SVC_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}
+NAGIOS_EC_LINE_ENABLE_HOST_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_HOST_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}
+NAGIOS_EC_LINE_ENABLE_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS:[nagios][log][command]};%{DATA:[host][hostname]};%{GREEDYDATA:[nagios][log][service]}
 
 #Schedule host & service downtime
-NAGIOS_EC_LINE_SCHEDULE_HOST_DOWNTIME %{NAGIOS_TYPE_EXTERNAL_COMMAND:nagios_type}: %{NAGIOS_EC_SCHEDULE_HOST_DOWNTIME:nagios_command};%{DATA:nagios_hostname};%{NUMBER:nagios_start_time};%{NUMBER:nagios_end_time};%{NUMBER:nagios_fixed};%{NUMBER:nagios_trigger_id};%{NUMBER:nagios_duration};%{DATA:author};%{DATA:comment}
+NAGIOS_EC_LINE_SCHEDULE_HOST_DOWNTIME %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_SCHEDULE_HOST_DOWNTIME:[nagios][log][command]};%{DATA:[host][hostname]};%{NUMBER:[nagios][log][start_time]};%{NUMBER:[nagios][log][end_time]};%{NUMBER:[nagios][log][fixed]};%{NUMBER:[nagios][log][trigger_id]};%{NUMBER:[nagios][log][duration]:int};%{DATA:[user][name]};%{DATA:[nagios][log][comment]}
 
 #End matching line
 NAGIOSLOGLINE %{NAGIOSTIME} (?:%{NAGIOS_WARNING}|%{NAGIOS_CURRENT_SERVICE_STATE}|%{NAGIOS_CURRENT_HOST_STATE}|%{NAGIOS_SERVICE_NOTIFICATION}|%{NAGIOS_HOST_NOTIFICATION}|%{NAGIOS_SERVICE_ALERT}|%{NAGIOS_HOST_ALERT}|%{NAGIOS_SERVICE_FLAPPING_ALERT}|%{NAGIOS_HOST_FLAPPING_ALERT}|%{NAGIOS_SERVICE_DOWNTIME_ALERT}|%{NAGIOS_HOST_DOWNTIME_ALERT}|%{NAGIOS_PASSIVE_SERVICE_CHECK}|%{NAGIOS_PASSIVE_HOST_CHECK}|%{NAGIOS_SERVICE_EVENT_HANDLER}|%{NAGIOS_HOST_EVENT_HANDLER}|%{NAGIOS_TIMEPERIOD_TRANSITION}|%{NAGIOS_EC_LINE_DISABLE_SVC_CHECK}|%{NAGIOS_EC_LINE_ENABLE_SVC_CHECK}|%{NAGIOS_EC_LINE_DISABLE_HOST_CHECK}|%{NAGIOS_EC_LINE_ENABLE_HOST_CHECK}|%{NAGIOS_EC_LINE_PROCESS_HOST_CHECK_RESULT}|%{NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT}|%{NAGIOS_EC_LINE_SCHEDULE_HOST_DOWNTIME}|%{NAGIOS_EC_LINE_DISABLE_HOST_SVC_NOTIFICATIONS}|%{NAGIOS_EC_LINE_ENABLE_HOST_SVC_NOTIFICATIONS}|%{NAGIOS_EC_LINE_DISABLE_HOST_NOTIFICATIONS}|%{NAGIOS_EC_LINE_ENABLE_HOST_NOTIFICATIONS}|%{NAGIOS_EC_LINE_DISABLE_SVC_NOTIFICATIONS}|%{NAGIOS_EC_LINE_ENABLE_SVC_NOTIFICATIONS})

--- a/patterns/ecs-v1/nagios
+++ b/patterns/ecs-v1/nagios
@@ -68,26 +68,26 @@ NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS ENABLE_SVC_NOTIFICATIONS
 ###############################################
 NAGIOS_WARNING Warning:%{SPACE}%{GREEDYDATA:message}
 
-NAGIOS_CURRENT_SERVICE_STATE %{NAGIOS_TYPE_CURRENT_SERVICE_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
-NAGIOS_CURRENT_HOST_STATE %{NAGIOS_TYPE_CURRENT_HOST_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
+NAGIOS_CURRENT_SERVICE_STATE %{NAGIOS_TYPE_CURRENT_SERVICE_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[service][state]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
+NAGIOS_CURRENT_HOST_STATE %{NAGIOS_TYPE_CURRENT_HOST_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][state]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_NOTIFICATION %{NAGIOS_TYPE_SERVICE_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
-NAGIOS_HOST_NOTIFICATION %{NAGIOS_TYPE_HOST_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
+NAGIOS_SERVICE_NOTIFICATION %{NAGIOS_TYPE_SERVICE_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[service][state]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
+NAGIOS_HOST_NOTIFICATION %{NAGIOS_TYPE_HOST_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[service][state]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_ALERT %{NAGIOS_TYPE_SERVICE_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
-NAGIOS_HOST_ALERT %{NAGIOS_TYPE_HOST_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
+NAGIOS_SERVICE_ALERT %{NAGIOS_TYPE_SERVICE_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[service][state]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
+NAGIOS_HOST_ALERT %{NAGIOS_TYPE_HOST_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][state]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_FLAPPING_ALERT %{NAGIOS_TYPE_SERVICE_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{GREEDYDATA:message}
-NAGIOS_HOST_FLAPPING_ALERT %{NAGIOS_TYPE_HOST_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:message}
+NAGIOS_SERVICE_FLAPPING_ALERT %{NAGIOS_TYPE_SERVICE_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[service][state]};%{GREEDYDATA:message}
+NAGIOS_HOST_FLAPPING_ALERT %{NAGIOS_TYPE_HOST_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][state]};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_DOWNTIME_ALERT %{NAGIOS_TYPE_SERVICE_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
-NAGIOS_HOST_DOWNTIME_ALERT %{NAGIOS_TYPE_HOST_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
+NAGIOS_SERVICE_DOWNTIME_ALERT %{NAGIOS_TYPE_SERVICE_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[service][state]};%{GREEDYDATA:[nagios][log][comment]}
+NAGIOS_HOST_DOWNTIME_ALERT %{NAGIOS_TYPE_HOST_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][state]};%{GREEDYDATA:[nagios][log][comment]}
 
-NAGIOS_PASSIVE_SERVICE_CHECK %{NAGIOS_TYPE_PASSIVE_SERVICE_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
-NAGIOS_PASSIVE_HOST_CHECK %{NAGIOS_TYPE_PASSIVE_HOST_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
+NAGIOS_PASSIVE_SERVICE_CHECK %{NAGIOS_TYPE_PASSIVE_SERVICE_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[service][state]};%{GREEDYDATA:[nagios][log][comment]}
+NAGIOS_PASSIVE_HOST_CHECK %{NAGIOS_TYPE_PASSIVE_HOST_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][state]};%{GREEDYDATA:[nagios][log][comment]}
 
-NAGIOS_SERVICE_EVENT_HANDLER %{NAGIOS_TYPE_SERVICE_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
-NAGIOS_HOST_EVENT_HANDLER %{NAGIOS_TYPE_HOST_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
+NAGIOS_SERVICE_EVENT_HANDLER %{NAGIOS_TYPE_SERVICE_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[service][state]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
+NAGIOS_HOST_EVENT_HANDLER %{NAGIOS_TYPE_HOST_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][state]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
 
 NAGIOS_TIMEPERIOD_TRANSITION %{NAGIOS_TYPE_TIMEPERIOD_TRANSITION:[nagios][log][type]}: %{DATA:[service][name]};%{NUMBER:[nagios][log][period_from]:int};%{NUMBER:[nagios][log][period_to]:int}
 
@@ -104,8 +104,8 @@ NAGIOS_EC_LINE_ENABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][typ
 NAGIOS_EC_LINE_ENABLE_HOST_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_HOST_CHECK:[nagios][log][command]};%{DATA:[host][hostname]}
 
 #Process host & service check
-NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_SERVICE_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][check_result]}
-NAGIOS_EC_LINE_PROCESS_HOST_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_HOST_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][check_result]}
+NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_SERVICE_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[service][state]};%{GREEDYDATA:[nagios][log][check_result]}
+NAGIOS_EC_LINE_PROCESS_HOST_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_HOST_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[service][state]};%{GREEDYDATA:[nagios][log][check_result]}
 
 #Disable host & service notifications
 NAGIOS_EC_LINE_DISABLE_HOST_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_HOST_SVC_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}

--- a/patterns/ecs-v1/nagios
+++ b/patterns/ecs-v1/nagios
@@ -68,54 +68,54 @@ NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS ENABLE_SVC_NOTIFICATIONS
 ###############################################
 NAGIOS_WARNING Warning:%{SPACE}%{GREEDYDATA:message}
 
-NAGIOS_CURRENT_SERVICE_STATE %{NAGIOS_TYPE_CURRENT_SERVICE_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
+NAGIOS_CURRENT_SERVICE_STATE %{NAGIOS_TYPE_CURRENT_SERVICE_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
 NAGIOS_CURRENT_HOST_STATE %{NAGIOS_TYPE_CURRENT_HOST_STATE:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_NOTIFICATION %{NAGIOS_TYPE_SERVICE_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
+NAGIOS_SERVICE_NOTIFICATION %{NAGIOS_TYPE_SERVICE_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
 NAGIOS_HOST_NOTIFICATION %{NAGIOS_TYPE_HOST_NOTIFICATION:[nagios][log][type]}: %{DATA:[user][name]};%{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][notification_command]};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_ALERT %{NAGIOS_TYPE_SERVICE_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
+NAGIOS_SERVICE_ALERT %{NAGIOS_TYPE_SERVICE_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
 NAGIOS_HOST_ALERT %{NAGIOS_TYPE_HOST_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{INT:[nagios][log][attempt]:int};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_FLAPPING_ALERT %{NAGIOS_TYPE_SERVICE_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{GREEDYDATA:message}
+NAGIOS_SERVICE_FLAPPING_ALERT %{NAGIOS_TYPE_SERVICE_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{GREEDYDATA:message}
 NAGIOS_HOST_FLAPPING_ALERT %{NAGIOS_TYPE_HOST_FLAPPING_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:message}
 
-NAGIOS_SERVICE_DOWNTIME_ALERT %{NAGIOS_TYPE_SERVICE_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
+NAGIOS_SERVICE_DOWNTIME_ALERT %{NAGIOS_TYPE_SERVICE_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
 NAGIOS_HOST_DOWNTIME_ALERT %{NAGIOS_TYPE_HOST_DOWNTIME_ALERT:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
 
-NAGIOS_PASSIVE_SERVICE_CHECK %{NAGIOS_TYPE_PASSIVE_SERVICE_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
+NAGIOS_PASSIVE_SERVICE_CHECK %{NAGIOS_TYPE_PASSIVE_SERVICE_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
 NAGIOS_PASSIVE_HOST_CHECK %{NAGIOS_TYPE_PASSIVE_HOST_CHECK:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][comment]}
 
-NAGIOS_SERVICE_EVENT_HANDLER %{NAGIOS_TYPE_SERVICE_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
+NAGIOS_SERVICE_EVENT_HANDLER %{NAGIOS_TYPE_SERVICE_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
 NAGIOS_HOST_EVENT_HANDLER %{NAGIOS_TYPE_HOST_EVENT_HANDLER:[nagios][log][type]}: %{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{DATA:[nagios][log][state_type]};%{DATA:[nagios][log][event_handler_name]}
 
-NAGIOS_TIMEPERIOD_TRANSITION %{NAGIOS_TYPE_TIMEPERIOD_TRANSITION:[nagios][log][type]}: %{DATA:[nagios][log][service]};%{NUMBER:[nagios][log][period_from]:int};%{NUMBER:[nagios][log][period_to]:int}
+NAGIOS_TIMEPERIOD_TRANSITION %{NAGIOS_TYPE_TIMEPERIOD_TRANSITION:[nagios][log][type]}: %{DATA:[service][name]};%{NUMBER:[nagios][log][period_from]:int};%{NUMBER:[nagios][log][period_to]:int}
 
 ####################
 #### External checks
 ####################
 
 #Disable host & service check
-NAGIOS_EC_LINE_DISABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_SVC_CHECK:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][service]}
+NAGIOS_EC_LINE_DISABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_SVC_CHECK:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[service][name]}
 NAGIOS_EC_LINE_DISABLE_HOST_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_HOST_CHECK:[nagios][log][command]};%{DATA:[host][hostname]}
 
 #Enable host & service check
-NAGIOS_EC_LINE_ENABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_SVC_CHECK:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][service]}
+NAGIOS_EC_LINE_ENABLE_SVC_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_SVC_CHECK:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[service][name]}
 NAGIOS_EC_LINE_ENABLE_HOST_CHECK %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_HOST_CHECK:[nagios][log][command]};%{DATA:[host][hostname]}
 
 #Process host & service check
-NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_SERVICE_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][service]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][check_result]}
+NAGIOS_EC_LINE_PROCESS_SERVICE_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_SERVICE_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[service][name]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][check_result]}
 NAGIOS_EC_LINE_PROCESS_HOST_CHECK_RESULT %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_PROCESS_HOST_CHECK_RESULT:[nagios][log][command]};%{DATA:[host][hostname]};%{DATA:[nagios][log][status]};%{GREEDYDATA:[nagios][log][check_result]}
 
 #Disable host & service notifications
 NAGIOS_EC_LINE_DISABLE_HOST_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_HOST_SVC_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}
 NAGIOS_EC_LINE_DISABLE_HOST_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_HOST_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}
-NAGIOS_EC_LINE_DISABLE_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_SVC_NOTIFICATIONS:[nagios][log][command]};%{DATA:[host][hostname]};%{GREEDYDATA:[nagios][log][service]}
+NAGIOS_EC_LINE_DISABLE_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_DISABLE_SVC_NOTIFICATIONS:[nagios][log][command]};%{DATA:[host][hostname]};%{GREEDYDATA:[service][name]}
 
 #Enable host & service notifications
 NAGIOS_EC_LINE_ENABLE_HOST_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_HOST_SVC_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}
 NAGIOS_EC_LINE_ENABLE_HOST_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_HOST_NOTIFICATIONS:[nagios][log][command]};%{GREEDYDATA:[host][hostname]}
-NAGIOS_EC_LINE_ENABLE_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS:[nagios][log][command]};%{DATA:[host][hostname]};%{GREEDYDATA:[nagios][log][service]}
+NAGIOS_EC_LINE_ENABLE_SVC_NOTIFICATIONS %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_ENABLE_SVC_NOTIFICATIONS:[nagios][log][command]};%{DATA:[host][hostname]};%{GREEDYDATA:[service][name]}
 
 #Schedule host & service downtime
 NAGIOS_EC_LINE_SCHEDULE_HOST_DOWNTIME %{NAGIOS_TYPE_EXTERNAL_COMMAND:[nagios][log][type]}: %{NAGIOS_EC_SCHEDULE_HOST_DOWNTIME:[nagios][log][command]};%{DATA:[host][hostname]};%{NUMBER:[nagios][log][start_time]};%{NUMBER:[nagios][log][end_time]};%{NUMBER:[nagios][log][fixed]};%{NUMBER:[nagios][log][trigger_id]};%{NUMBER:[nagios][log][duration]:int};%{DATA:[user][name]};%{DATA:[nagios][log][comment]}

--- a/spec/patterns/nagios_spec.rb
+++ b/spec/patterns/nagios_spec.rb
@@ -40,7 +40,7 @@ describe_pattern "NAGIOSLOGLINE - CURRENT HOST STATE", [ 'legacy', 'ecs-v1' ] do
 
   it "generates the nagios_state field" do
     if ecs_compatibility?
-      expect(grok).to include("nagios" => hash_including("log" => hash_including("status" => "UP")))
+      expect(grok).to include("service" => hash_including("state" => "UP"))
     else
       expect(grok).to include("nagios_state" => "UP")
     end
@@ -110,7 +110,7 @@ describe_pattern "NAGIOSLOGLINE - CURRENT SERVICE STATE", [ 'legacy', 'ecs-v1' ]
 
   it "generates the nagios_state field" do
     if ecs_compatibility?
-      expect(grok).to include("nagios" => hash_including("log" => hash_including("status" => "OK")))
+      expect(grok).to include("service" => hash_including("state" => "OK"))
     else
       expect(grok).to include("nagios_state" => "OK")
     end
@@ -143,10 +143,9 @@ describe_pattern "NAGIOSLOGLINE - CURRENT SERVICE STATE", [ 'legacy', 'ecs-v1' ]
       if ecs_compatibility?
         expect(grok).to include(
           "host" => { "hostname" => "prod-virtual-ESz06" },
-          "service" => { "name" => "check_vmfs_prod-PvDC2" },
+          "service" => { "name" => "check_vmfs_prod-PvDC2", "state" => 'CRITICAL' },
           "nagios" => { "log" => {
               "type" => "CURRENT SERVICE STATE",
-              "status" => "CRITICAL",
               "state_type" => "HARD",
               "attempt" => 3
           }},
@@ -258,7 +257,7 @@ describe_pattern "NAGIOSLOGLINE - SERVICE ALERT", [ 'legacy', 'ecs-v1' ] do
 
   it "generates the nagios_state field" do
     if ecs_compatibility?
-      expect(grok).to include("nagios" => hash_including("log" => hash_including("status" => "CRITICAL")))
+      expect(grok).to include("service" => hash_including("state" => "CRITICAL"))
     else
       expect(grok).to include("nagios_state" => "CRITICAL")
     end
@@ -347,7 +346,7 @@ describe_pattern "NAGIOSLOGLINE - SERVICE NOTIFICATION", [ 'legacy', 'ecs-v1' ] 
 
   it "generates the nagios_state field" do
     if ecs_compatibility?
-      expect(grok).to include("nagios" => hash_including("log" => hash_including("status" => "CRITICAL")))
+      expect(grok).to include("service" => hash_including("state" => "CRITICAL"))
     else
       expect(grok).to include("nagios_state" => "CRITICAL")
     end

--- a/spec/patterns/nagios_spec.rb
+++ b/spec/patterns/nagios_spec.rb
@@ -92,7 +92,7 @@ describe_pattern "NAGIOSLOGLINE - CURRENT SERVICE STATE", [ 'legacy', 'ecs-v1' ]
     end
   end
 
-  it "generates the nagios_hostname field" do
+  it "generates the hostname field" do
     if ecs_compatibility?
       expect(grok).to include("host" => { "hostname" => "nagioshost" })
     else
@@ -100,9 +100,9 @@ describe_pattern "NAGIOSLOGLINE - CURRENT SERVICE STATE", [ 'legacy', 'ecs-v1' ]
     end
   end
 
-  it "generates the nagios_service field" do
+  it "generates the service field" do
     if ecs_compatibility?
-      expect(grok).to include("nagios" => hash_including("log" => hash_including("service" => "SSH")))
+      expect(grok).to include("service" => hash_including("name" => "SSH"))
     else
       expect(grok).to include("nagios_service" => "SSH")
     end
@@ -143,12 +143,12 @@ describe_pattern "NAGIOSLOGLINE - CURRENT SERVICE STATE", [ 'legacy', 'ecs-v1' ]
       if ecs_compatibility?
         expect(grok).to include(
           "host" => { "hostname" => "prod-virtual-ESz06" },
+          "service" => { "name" => "check_vmfs_prod-PvDC2" },
           "nagios" => { "log" => {
               "type" => "CURRENT SERVICE STATE",
               "status" => "CRITICAL",
               "state_type" => "HARD",
-              "attempt" => 3,
-              "service" => "check_vmfs_prod-PvDC2"
+              "attempt" => 3
           }},
           "message" => [message, "CRITICAL - /vmfs/volumes/prod-vsRoot - total: 8191.75 Gb - used: 7859.84 Gb (95%)- free: 331.90 Gb (5%)"]
         )
@@ -187,9 +187,9 @@ describe_pattern "NAGIOSLOGLINE - TIMEPERIOD TRANSITION", [ 'legacy', 'ecs-v1' ]
     expect(grok).to include("nagios_epoch" => "1427925600") unless ecs_compatibility?
   end
 
-  it "generates the nagios_service field" do
+  it "generates the service field" do
     if ecs_compatibility?
-      expect(grok).to include("nagios" => hash_including("log" => hash_including("service" => '24X7')))
+      expect(grok).to include("service" => hash_including("name" => '24X7'))
     else
       expect(grok).to include("nagios_service" => "24X7")
     end
@@ -240,7 +240,7 @@ describe_pattern "NAGIOSLOGLINE - SERVICE ALERT", [ 'legacy', 'ecs-v1' ] do
     end
   end
 
-  it "generates the nagios_hostname field" do
+  it "generates the hostname field" do
     if ecs_compatibility?
       expect(grok).to include("host" => { "hostname" => "varnish" })
     else
@@ -248,9 +248,9 @@ describe_pattern "NAGIOSLOGLINE - SERVICE ALERT", [ 'legacy', 'ecs-v1' ] do
     end
   end
 
-  it "generates the nagios_service field" do
+  it "generates the service field" do
     if ecs_compatibility?
-      expect(grok).to include("nagios" => hash_including("log" => hash_including("service" => 'Varnish Backend Connections')))
+      expect(grok).to include("service" => hash_including("name" => 'Varnish Backend Connections'))
     else
       expect(grok).to include("nagios_service" => "Varnish Backend Connections")
     end
@@ -329,7 +329,7 @@ describe_pattern "NAGIOSLOGLINE - SERVICE NOTIFICATION", [ 'legacy', 'ecs-v1' ] 
     end
   end
 
-  it "generates the nagios_hostname field" do
+  it "generates the hostname field" do
     if ecs_compatibility?
       expect(grok).to include("host" => { "hostname" => "varnish" })
     else
@@ -337,9 +337,9 @@ describe_pattern "NAGIOSLOGLINE - SERVICE NOTIFICATION", [ 'legacy', 'ecs-v1' ] 
     end
   end
 
-  it "generates the nagios_service field" do
+  it "generates the service field" do
     if ecs_compatibility?
-      expect(grok).to include("nagios" => hash_including("log" => hash_including("service" => 'Varnish Backend Connections')))
+      expect(grok).to include("service" => hash_including("name" => 'Varnish Backend Connections'))
     else
       expect(grok).to include("nagios_service" => "Varnish Backend Connections")
     end

--- a/spec/patterns/nagios_spec.rb
+++ b/spec/patterns/nagios_spec.rb
@@ -274,10 +274,11 @@ describe_pattern "NAGIOSLOGLINE - SERVICE ALERT", [ 'legacy', 'ecs-v1' ] do
 
   it "generates the nagios_attempt field" do
     if ecs_compatibility?
-      p grok
+      pending "TODO: are we hitting a grok bug here ?!?"
+      # [nagios][log][attempt]:int is clearly there (changing to :float gets this passing)
+      # ... but in this particular case we still get the raw "1" string back
       expect(grok).to include("nagios" => hash_including("log" => hash_including("attempt" => 1)))
     else
-      p grok
       expect(grok).to include("nagios_attempt" => "1")
     end
   end

--- a/spec/patterns/nagios_spec.rb
+++ b/spec/patterns/nagios_spec.rb
@@ -2,246 +2,463 @@
 require "spec_helper"
 require "logstash/patterns/core"
 
-describe "NAGIOSLOGLINE - CURRENT HOST STATE" do
+describe_pattern "NAGIOSLOGLINE - CURRENT HOST STATE", [ 'legacy', 'ecs-v1' ] do
 
-  let(:value)   { "[1427925600] CURRENT HOST STATE: nagioshost;UP;HARD;1;PING OK - Packet loss = 0%, RTA = 2.24 ms" }
-  let(:grok)    { grok_match(subject, value) }
+  let(:message) { "[1427925600] CURRENT HOST STATE: nagioshost;UP;HARD;1;PING OK - Packet loss = 0%, RTA = 2.24 ms" }
 
   it "a pattern pass the grok expression" do
     expect(grok).to pass
   end
 
   it "matches a simple message" do
-    expect(subject).to match(value)
+    expect(pattern).to match(message)
   end
 
   it "generates the nagios_epoch field" do
-    expect(grok).to include("nagios_epoch" => "1427925600")
+    if ecs_compatibility?
+      expect(grok).to include("timestamp" => "1427925600")
+    else
+      expect(grok).to include("nagios_epoch" => "1427925600")
+    end
   end
 
   it "generates the nagios_message field" do
-    expect(grok).to include("nagios_message" => "PING OK - Packet loss = 0%, RTA = 2.24 ms")
+    if ecs_compatibility?
+      expect(grok).to include("message" => [message, "PING OK - Packet loss = 0%, RTA = 2.24 ms"])
+    else
+      expect(grok).to include("nagios_message" => "PING OK - Packet loss = 0%, RTA = 2.24 ms")
+    end
   end
 
   it "generates the nagios_hostname field" do
-    expect(grok).to include("nagios_hostname" => "nagioshost")
+    if ecs_compatibility?
+      expect(grok).to include("host" => { "hostname" => "nagioshost" })
+    else
+      expect(grok).to include("nagios_hostname" => "nagioshost")
+    end
   end
 
   it "generates the nagios_state field" do
-    expect(grok).to include("nagios_state" => "UP")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("status" => "UP")))
+    else
+      expect(grok).to include("nagios_state" => "UP")
+    end
   end
 
   it "generates the nagios_statetype field" do
-    expect(grok).to include("nagios_statetype" => "HARD")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("state_type" => "HARD")))
+    else
+      expect(grok).to include("nagios_statetype" => "HARD")
+    end
   end
 
 end
 
-describe "NAGIOSLOGLINE - CURRENT SERVICE STATE" do
+describe_pattern "NAGIOSLOGLINE - CURRENT SERVICE STATE", [ 'legacy', 'ecs-v1' ] do
 
-  let(:value)   { "[1427925600] CURRENT SERVICE STATE: nagioshost;nagiosservice;OK;HARD;1;nagiosmessage" }
-  let(:grok)    { grok_match(subject, value) }
+  let(:message) { "[1427925600] CURRENT SERVICE STATE: nagioshost;SSH;OK;HARD;1;nagiosmessage" }
 
   it "a pattern pass the grok expression" do
     expect(grok).to pass
   end
 
   it "matches a simple message" do
-    expect(subject).to match(value)
+    expect(pattern).to match(message)
   end
 
   it "generates the nagios_type field" do
-    expect(grok).to include("nagios_type" => "CURRENT SERVICE STATE")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("type" => "CURRENT SERVICE STATE")))
+    else
+      expect(grok).to include("nagios_type" => "CURRENT SERVICE STATE")
+    end
   end
 
   it "generates the nagios_epoch field" do
-    expect(grok).to include("nagios_epoch" => "1427925600")
+    if ecs_compatibility?
+      expect(grok).to include("timestamp" => "1427925600")
+    else
+      expect(grok).to include("nagios_epoch" => "1427925600")
+    end
   end
 
   it "generates the nagios_message field" do
-    expect(grok).to include("nagios_message" => "nagiosmessage")
+    if ecs_compatibility?
+      expect(grok).to include("message" => [message, "nagiosmessage"])
+    else
+      expect(grok).to include("nagios_message" => "nagiosmessage")
+    end
   end
 
   it "generates the nagios_hostname field" do
-    expect(grok).to include("nagios_hostname" => "nagioshost")
+    if ecs_compatibility?
+      expect(grok).to include("host" => { "hostname" => "nagioshost" })
+    else
+      expect(grok).to include("nagios_hostname" => "nagioshost")
+    end
   end
 
   it "generates the nagios_service field" do
-    expect(grok).to include("nagios_service" => "nagiosservice")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("service" => "SSH")))
+    else
+      expect(grok).to include("nagios_service" => "SSH")
+    end
   end
 
   it "generates the nagios_state field" do
-    expect(grok).to include("nagios_state" => "OK")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("status" => "OK")))
+    else
+      expect(grok).to include("nagios_state" => "OK")
+    end
   end
 
   it "generates the nagios_statetype field" do
-    expect(grok).to include("nagios_statetype" => "HARD")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("state_type" => "HARD")))
+    else
+      expect(grok).to include("nagios_statetype" => "HARD")
+    end
   end
 
+  it "generates the nagios_statecode field" do
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("attempt" => 1)))
+    else
+      # NOTE: (legacy) nagios_statecode corresponds to current_attempt (according to Nagios' source)
+      expect(grok).to include("nagios_statecode" => "1")
+    end
+  end
+
+  context 'real-world example' do
+
+    let(:message) do
+      '[1427956600] CURRENT SERVICE STATE: prod-virtual-ESz06;check_vmfs_prod-PvDC2;CRITICAL;HARD;3;CRITICAL - /vmfs/volumes/prod-vsRoot - total: 8191.75 Gb - used: 7859.84 Gb (95%)- free: 331.90 Gb (5%)'
+    end
+
+    it 'matches' do
+      if ecs_compatibility?
+        expect(grok).to include(
+          "host" => { "hostname" => "prod-virtual-ESz06" },
+          "nagios" => { "log" => {
+              "type" => "CURRENT SERVICE STATE",
+              "status" => "CRITICAL",
+              "state_type" => "HARD",
+              "attempt" => 3,
+              "service" => "check_vmfs_prod-PvDC2"
+          }},
+          "message" => [message, "CRITICAL - /vmfs/volumes/prod-vsRoot - total: 8191.75 Gb - used: 7859.84 Gb (95%)- free: 331.90 Gb (5%)"]
+        )
+      else
+        expect(grok).to include(
+          "nagios_type"=>"CURRENT SERVICE STATE",
+          "nagios_state"=>"CRITICAL",
+          "nagios_statetype"=>"HARD",
+          "nagios_hostname"=>"prod-virtual-ESz06",
+          "nagios_statecode"=>"3", # NOTE: "incorrect" - corresponds to current_attempt (according to Nagios' source)
+          "nagios_message"=>"CRITICAL - /vmfs/volumes/prod-vsRoot - total: 8191.75 Gb - used: 7859.84 Gb (95%)- free: 331.90 Gb (5%)"
+        )
+      end
+    end
+
+  end
 end
 
-describe "NAGIOSLOGLINE - TIMEPERIOD TRANSITION" do
+describe_pattern "NAGIOSLOGLINE - TIMEPERIOD TRANSITION", [ 'legacy', 'ecs-v1' ] do
 
-  let(:value)   { "[1427925600] TIMEPERIOD TRANSITION: 24X7;-1;1" }
-  let(:grok)    { grok_match(subject, value) }
+  let(:message) { "[1427925600] TIMEPERIOD TRANSITION: 24X7;-1;1" }
 
-  it "a pattern pass the grok expression" do
-    expect(grok).to pass
-  end
-
-  it "matches a simple message" do
-    expect(subject).to match(value)
+  it "matches the message" do
+    expect(pattern).to match(message)
   end
 
   it "generates the nagios_type field" do
-    expect(grok).to include("nagios_type" => "TIMEPERIOD TRANSITION")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("type" => 'TIMEPERIOD TRANSITION')))
+    else
+      expect(grok).to include("nagios_type" => "TIMEPERIOD TRANSITION")
+    end
   end
 
   it "generates the nagios_epoch field" do
-    expect(grok).to include("nagios_epoch" => "1427925600")
+    expect(grok).to include("nagios_epoch" => "1427925600") unless ecs_compatibility?
   end
 
-  it "generates the nagios_esrvice field" do
-    expect(grok).to include("nagios_service" => "24X7")
+  it "generates the nagios_service field" do
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("service" => '24X7')))
+    else
+      expect(grok).to include("nagios_service" => "24X7")
+    end
   end
 
   it "generates the period from/to fields" do
-    expect(grok).to include("nagios_unknown1" => "-1", "nagios_unknown2" => "1")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("period_from" => -1, "period_to" => 1)))
+    else
+      expect(grok).to include("nagios_unknown1" => "-1", "nagios_unknown2" => "1")
+    end
   end
 
   # Regression test for but fixed in Nagios patterns #30
   it "doesn't end in a semi-colon" do
-    expect(grok['message']).to_not end_with(";")
+    message = grok['message']
+    message = message.last if message.is_a?(Array)
+    expect(message).to_not end_with(";")
   end
 
 end
 
-describe "NAGIOSLOGLINE - SERVICE ALERT" do
+describe_pattern "NAGIOSLOGLINE - SERVICE ALERT", [ 'legacy', 'ecs-v1' ] do
 
-  let(:value)   { "[1427925689] SERVICE ALERT: varnish;Varnish Backend Connections;CRITICAL;SOFT;1;Current value: 154.0, warn threshold: 10.0, crit threshold: 20.0" }
-  let(:grok)    { grok_match(subject, value) }
+  let(:message) { "[1427925689] SERVICE ALERT: varnish;Varnish Backend Connections;CRITICAL;SOFT;1;Current value: 154.0, warn threshold: 10.0, crit threshold: 20.0" }
 
   it "a pattern pass the grok expression" do
     expect(grok).to pass
   end
 
   it "matches a simple message" do
-    expect(subject).to match(value)
+    expect(pattern).to match(message)
   end
 
   it "generates the nagios_type field" do
-    expect(grok).to include("nagios_type" => "SERVICE ALERT")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("type" => 'SERVICE ALERT')))
+    else
+      expect(grok).to include("nagios_type" => "SERVICE ALERT")
+    end
   end
 
   it "generates the nagios_epoch field" do
-    expect(grok).to include("nagios_epoch" => "1427925689")
+    if ecs_compatibility?
+      expect(grok).to include("timestamp" => "1427925689")
+    else
+      expect(grok).to include("nagios_epoch" => "1427925689")
+    end
   end
 
   it "generates the nagios_hostname field" do
-    expect(grok).to include("nagios_hostname" => "varnish")
+    if ecs_compatibility?
+      expect(grok).to include("host" => { "hostname" => "varnish" })
+    else
+      expect(grok).to include("nagios_hostname" => "varnish")
+    end
   end
 
   it "generates the nagios_service field" do
-    expect(grok).to include("nagios_service" => "Varnish Backend Connections")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("service" => 'Varnish Backend Connections')))
+    else
+      expect(grok).to include("nagios_service" => "Varnish Backend Connections")
+    end
   end
 
   it "generates the nagios_state field" do
-    expect(grok).to include("nagios_state" => "CRITICAL")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("status" => "CRITICAL")))
+    else
+      expect(grok).to include("nagios_state" => "CRITICAL")
+    end
   end
 
   it "generates the nagios_statelevel field" do
-    expect(grok).to include("nagios_statelevel" => "SOFT")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("state_type" => "SOFT")))
+    else
+      expect(grok).to include("nagios_statelevel" => "SOFT")
+    end
+  end
+
+  it "generates the nagios_attempt field" do
+    if ecs_compatibility?
+      p grok
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("attempt" => 1)))
+    else
+      p grok
+      expect(grok).to include("nagios_attempt" => "1")
+    end
   end
 
   it "generates the nagios_message field" do
-    expect(grok).to include("nagios_message" => "Current value: 154.0, warn threshold: 10.0, crit threshold: 20.0")
+    if ecs_compatibility?
+      expect(grok['message'].last).to eql "Current value: 154.0, warn threshold: 10.0, crit threshold: 20.0"
+    else
+      expect(grok).to include("nagios_message" => "Current value: 154.0, warn threshold: 10.0, crit threshold: 20.0")
+    end
   end
 
 end
 
-describe "NAGIOSLOGLINE - SERVICE NOTIFICATION" do
+describe_pattern "NAGIOSLOGLINE - SERVICE NOTIFICATION", [ 'legacy', 'ecs-v1' ] do
 
-  let(:value)   { "[1427950229] SERVICE NOTIFICATION: nagiosadmin;varnish;Varnish Backend Connections;CRITICAL;notify-service-by-email;Current value: 337.0, warn threshold: 10.0, crit threshold: 20.0" }
-  let(:grok)    { grok_match(subject, value) }
+  let(:message) { "[1427950229] SERVICE NOTIFICATION: nagiosadmin;varnish;Varnish Backend Connections;CRITICAL;notify-service-by-email;Current value: 337.0, warn threshold: 10.0, crit threshold: 20.0" }
 
   it "a pattern pass the grok expression" do
     expect(grok).to pass
   end
 
   it "matches a simple message" do
-    expect(subject).to match(value)
+    expect(pattern).to match(message)
   end
 
   it "generates the nagios_type field" do
-    expect(grok).to include("nagios_type" => "SERVICE NOTIFICATION")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("type" => 'SERVICE NOTIFICATION')))
+    else
+      expect(grok).to include("nagios_type" => "SERVICE NOTIFICATION")
+    end
   end
 
   it "generates the nagios_epoch field" do
-    expect(grok).to include("nagios_epoch" => "1427950229")
+    if ecs_compatibility?
+      expect(grok).to include("timestamp" => "1427950229")
+    else
+      expect(grok).to include("nagios_epoch" => "1427950229")
+    end
   end
 
   it "generates the nagios_notifyname field" do
-    expect(grok).to include("nagios_notifyname" => "nagiosadmin")
+    if ecs_compatibility?
+      expect(grok).to include("user" => { "name" => "nagiosadmin" }) # Nagios contact's contact_name
+    else
+      expect(grok).to include("nagios_notifyname" => "nagiosadmin")
+    end
   end
 
   it "generates the nagios_hostname field" do
-    expect(grok).to include("nagios_hostname" => "varnish")
+    if ecs_compatibility?
+      expect(grok).to include("host" => { "hostname" => "varnish" })
+    else
+      expect(grok).to include("nagios_hostname" => "varnish")
+    end
   end
 
   it "generates the nagios_service field" do
-    expect(grok).to include("nagios_service" => "Varnish Backend Connections")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("service" => 'Varnish Backend Connections')))
+    else
+      expect(grok).to include("nagios_service" => "Varnish Backend Connections")
+    end
   end
 
   it "generates the nagios_state field" do
-    expect(grok).to include("nagios_state" => "CRITICAL")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("status" => "CRITICAL")))
+    else
+      expect(grok).to include("nagios_state" => "CRITICAL")
+    end
   end
 
   it "generates the nagios_contact field" do
-    expect(grok).to include("nagios_contact" => "notify-service-by-email")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("notification_command" => "notify-service-by-email")))
+    else
+      expect(grok).to include("nagios_contact" => "notify-service-by-email")
+    end
   end
 
   it "generates the nagios_message field" do
-    expect(grok).to include("nagios_message" => "Current value: 337.0, warn threshold: 10.0, crit threshold: 20.0")
+    if ecs_compatibility?
+      expect(grok['message'].last).to eql "Current value: 337.0, warn threshold: 10.0, crit threshold: 20.0"
+    else
+      expect(grok).to include("nagios_message" => "Current value: 337.0, warn threshold: 10.0, crit threshold: 20.0")
+    end
   end
 
 end
 
 
-describe "NAGIOSLOGLINE - HOST NOTIFICATION" do
+describe_pattern "NAGIOSLOGLINE - HOST NOTIFICATION", [ 'legacy', 'ecs-v1' ] do
 
-  let(:value)   { "[1429878690] HOST NOTIFICATION: nagiosadmin;nagioshost;DOWN;notify-host-by-email;CRITICAL - Socket timeout after 10 seconds" }
-  let(:grok)    { grok_match(subject, value) }
-
-  it "a pattern pass the grok expression" do
-    expect(grok).to pass
-  end
+  let(:message) { "[1429878690] HOST NOTIFICATION: nagiosadmin;127.0.0.1;DOWN;host-notify-by-email;CRITICAL - Socket timeout after 10 seconds" }
 
   it "matches a simple message" do
-    expect(subject).to match(value)
+    expect(pattern).to match(message)
   end
 
   it "generates the nagios_type field" do
-    expect(grok).to include("nagios_type" => "HOST NOTIFICATION")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("type" => "HOST NOTIFICATION")))
+    else
+      expect(grok).to include("nagios_type" => "HOST NOTIFICATION")
+    end
   end
 
   it "generates the nagios_epoch field" do
-    expect(grok).to include("nagios_epoch" => "1429878690")
+    expect(grok).to include("nagios_epoch" => "1429878690") unless ecs_compatibility?
   end
 
   it "generates the nagios_notifyname field" do
-    expect(grok).to include("nagios_notifyname" => "nagiosadmin")
+    if ecs_compatibility?
+      expect(grok).to include("user" => { "name" => "nagiosadmin" }) # Nagios contact's contact_name
+    else
+      expect(grok).to include("nagios_notifyname" => "nagiosadmin")
+    end
   end
 
   it "generates the nagios_hostname field" do
-    expect(grok).to include("nagios_hostname" => "nagioshost")
+    if ecs_compatibility?
+      expect(grok).to include("host" => { "hostname" => "127.0.0.1" })
+    else
+      expect(grok).to include("nagios_hostname" => "127.0.0.1")
+    end
   end
 
   it "generates the nagios_contact field" do
-    expect(grok).to include("nagios_contact" => "notify-host-by-email")
+    if ecs_compatibility?
+      expect(grok).to include("nagios" => hash_including("log" => hash_including("notification_command" => "host-notify-by-email")))
+    else
+      expect(grok).to include("nagios_contact" => "host-notify-by-email")
+    end
   end
 
   it "generates the nagios_message field" do
-    expect(grok).to include("nagios_message" => "CRITICAL - Socket timeout after 10 seconds")
+    if ecs_compatibility?
+      expect(grok['message'].last).to eql "CRITICAL - Socket timeout after 10 seconds"
+    else
+      expect(grok).to include("nagios_message" => "CRITICAL - Socket timeout after 10 seconds")
+    end
   end
 
+end
+
+describe_pattern "NAGIOSLOGLINE - SCHEDULE_HOST_DOWNTIME", [ 'legacy', 'ecs-v1' ] do
+
+  let(:message) { "[1334609999] EXTERNAL COMMAND: SCHEDULE_HOST_DOWNTIME;sputnik;1334665800;1334553600;1;0;120;nagiosadmin;test;" }
+
+  it "matches" do
+    if ecs_compatibility?
+      expect(grok).to include(
+                          "host" => { "hostname" => "sputnik" },
+                          "nagios" => { "log" => {
+                              "type" => "EXTERNAL COMMAND",
+                              "command" => "SCHEDULE_HOST_DOWNTIME",
+                              "start_time" => "1334665800",
+                              "end_time" => "1334553600",
+                              "fixed" => '1',
+                              "trigger_id" => '0',
+                              "duration" => 120,
+
+                          }},
+                          "user" => { "name" => 'nagiosadmin' },
+                          "message" => message
+                      )
+    else
+      expect(grok).to include(
+                          "nagios_epoch"=>"1334609999",
+                          "nagios_type"=>"EXTERNAL COMMAND",
+                          "nagios_command"=>"SCHEDULE_HOST_DOWNTIME",
+                          "nagios_hostname"=>"sputnik",
+                          "nagios_duration"=>"120",
+                          "nagios_fixed"=>"1",
+                          "nagios_trigger_id"=>"0",
+                          "nagios_start_time"=>"1334665800",
+                          "nagios_end_time"=>"1334553600",
+                          "author"=>"nagiosadmin"
+      )
+    end
+  end
 end


### PR DESCRIPTION
Here I have mostly struggled with getting the naming right - too much "state"/"type" use in Nagios terminology.
Have decided to name "state status" as `status` (previously `nagios_state`) and state type as `state_type` (legacy name `nagios_statetype`)
The structure is rather flat to mirror Nagios (introducing `state: { type: "..." } ` would be an option but the terminology would not follow that well). It's a bit of a compromise, sample capture:

p.s. Some of the names were incorrect those have been fixed and specs should clearly reflect the change.

`[1427925600] CURRENT HOST STATE: nagioshost;UP;HARD;1;PING OK - Packet loss = 0%, RTA = 2.24 ms`
```
  "nagios_epoch"=>"1427925600", 
  "nagios_type"=>"CURRENT HOST STATE", 
  "nagios_hostname"=>"nagioshost", 
  "nagios_state"=>"UP", 
  "nagios_statetype"=>"HARD", 
  "nagios_statecode"=>"1", # incorrect -> simply an attempt counter
  "nagios_message"=>"PING OK - Packet loss = 0%, RTA = 2.24 ms", 
```

```
  "timestamp"=>"1427925600", 
  "nagios"=>{
    "log"=>{
      "type"=>"CURRENT HOST STATE", 
      "status"=>"UP", 
      "state_type"=>"HARD",
      "attempt"=>1, 
    }
  }, 
  "host"=>{"hostname"=>"nagioshost"},
  "message"=>"PING OK - Packet loss = 0%, RTA = 2.24 ms" ...
```

**NOTE**: now that I looked at ^^^ again I am going to revisit naming once again as the trio feels ackward:
```
      "type"=>"CURRENT HOST STATE", 
      "status"=>"UP", 
      "state_type"=>"HARD",
```
... maybe rename `status -> state` and potentially come up with a better name for the `type`