### PR TITLE
normalize HTTPD_COMBINEDLOG matching

### DIFF
--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -2,8 +2,8 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:clientip} (?:-|%{HTTPDUSER:ident}) (?:-|%{HTTPDUSER:auth}) \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" (?:-|%{NUMBER:response}) (?:-|%{NUMBER:bytes})
-HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} "(?:-|%{DATA:referrer})" "(?:-|%{DATA:agent})"
+HTTPD_COMMONLOG %{IPORHOST:clientip} %{HTTPDUSER:ident} %{HTTPDUSER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" (?:%{NUMBER:response}|-) (?:%{NUMBER:bytes}|-)
+HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:referrer} %{QS:agent}
 
 # Error logs
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:loglevel}\] (?:\[client %{IPORHOST:clientip}\] ){0,1}%{GREEDYDATA:message}

--- a/patterns/legacy/httpd
+++ b/patterns/legacy/httpd
@@ -2,8 +2,8 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:clientip} %{HTTPDUSER:ident} %{HTTPDUSER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:%{NUMBER:bytes}|-)
-HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:referrer} %{QS:agent}
+HTTPD_COMMONLOG %{IPORHOST:clientip} (?:-|%{HTTPDUSER:ident}) (?:-|%{HTTPDUSER:auth}) \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" (?:-|%{NUMBER:response}) (?:-|%{NUMBER:bytes})
+HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} "(?:-|%{DATA:referrer})" "(?:-|%{DATA:agent})"
 
 # Error logs
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:loglevel}\] (?:\[client %{IPORHOST:clientip}\] ){0,1}%{GREEDYDATA:message}

--- a/patterns/legacy/httpd
+++ b/patterns/legacy/httpd
@@ -2,7 +2,7 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:clientip} %{HTTPDUSER:ident} %{HTTPDUSER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:-|%{NUMBER:bytes})
+HTTPD_COMMONLOG %{IPORHOST:clientip} %{HTTPDUSER:ident} %{HTTPDUSER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" (?:%{NUMBER:response}|-) (?:%{NUMBER:bytes}|-)
 HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:referrer} %{QS:agent}
 
 # Error logs

--- a/patterns/legacy/httpd
+++ b/patterns/legacy/httpd
@@ -2,8 +2,8 @@ HTTPDUSER %{EMAILADDRESS}|%{USER}
 HTTPDERROR_DATE %{DAY} %{MONTH} %{MONTHDAY} %{TIME} %{YEAR}
 
 # Log formats
-HTTPD_COMMONLOG %{IPORHOST:clientip} (?:-|%{HTTPDUSER:ident}) (?:-|%{HTTPDUSER:auth}) \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" (?:-|%{NUMBER:response}) (?:-|%{NUMBER:bytes})
-HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} "(?:-|%{DATA:referrer})" "(?:-|%{DATA:agent})"
+HTTPD_COMMONLOG %{IPORHOST:clientip} %{HTTPDUSER:ident} %{HTTPDUSER:auth} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})" %{NUMBER:response} (?:-|%{NUMBER:bytes})
+HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} %{QS:referrer} %{QS:agent}
 
 # Error logs
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:loglevel}\] (?:\[client %{IPORHOST:clientip}\] ){0,1}%{GREEDYDATA:message}

--- a/spec/patterns/httpd_spec.rb
+++ b/spec/patterns/httpd_spec.rb
@@ -19,13 +19,13 @@ describe "HTTPD_COMBINEDLOG" do
         'httpversion' => '1.1',
         'response' => '200',
         'bytes' => '203023',
-        'referrer' => 'http://semicomplete.com/presentations/logstash-monitorama-2013/',
-        'agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36'
+        'referrer' => '"http://semicomplete.com/presentations/logstash-monitorama-2013/"',
+        'agent' => '"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36"'
       )
     end
 
     it "does not capture 'null' fields" do
-      expect(grok.keys).to_not include('ident', 'auth')
+      expect(grok).to include('auth' => '-', 'ident' => '-')
     end
 
   end


### PR DESCRIPTION
NOTE: these changes are the base-line for ECS-ification (https://github.com/logstash-plugins/logstash-patterns-core/pull/267 will rebase off this) and target *ecs-wip* branch.

Summary of changes :
- missing `ident`, user `auth`, `response` (code) fields will no longer be captured
  httpd indicates these nulls as `-`, meaning that there won't be a `'response' => "-"` for such line
- `referrer` and user `agent` fields will be de-quoted:
   previosly: `'referrer' => '"http://semicomplete.com/presentations/logstash-monitorama-2013/"'`
   changes to: `'referrer' => 'http://semicomplete.com/presentations/logstash-monitorama-2013/'`

These changes will be required for (later) ECS mode, the changes in null field matches are less concerning.
However matching `http.request.referrer` and `user_agent.original` needs to be "de-quoted" to align with ECS.

---

*Initially thought I'll just target this for master to be released "before" ECS is shipped.
Unfortunately, there isn't a version limiter in the grok filter (`s.add_runtime_dependency 'logstash-patterns-core'`) - so even if this was major it would eventually slip into the next LS (7.x) release.*

*Reasoning here is that we rather want changes done in relation to ECS to be shipped in one release so users update to changes such as outlined here while still using the legacy set and than handle the new ECS capture names (and type-casts) as the next step. Seems more work and confusion to me to ship these before hand.*
