### PR TITLE
(legacy) EXIM base-line for ECS-ification

### DIFF
--- a/patterns/legacy/exim
+++ b/patterns/legacy/exim
@@ -11,6 +11,9 @@ EXIM_MSG_SIZE (S=%{NUMBER:exim_msg_size})
 EXIM_HEADER_ID (id=%{NOTSPACE:exim_header_id})
 EXIM_SUBJECT (T=%{QS:exim_subject})
 
-EXIM_MESSAGE_ARRIVAL %{EXIM_DATE:timestamp} (?:%{EXIM_PID} )?%{EXIM_MSGID:exim_msgid} (?<exim_flags><=) (?:%{EXIM_FLAGS:exim_flags} )?(?<exim_status>[a-z:] )?%{EMAILADDRESS:exim_sender_email}(?: (?:%{EXIM_REMOTE_HOST}|%{EXIM_INTERFACE}|%{EXIM_PROTOCOL}|%{EXIM_MSG_SIZE}|%{EXIM_HEADER_ID}|%{EXIM_SUBJECT}|(?:[A-Za-z]{1,4}=%{NOTSPACE})))*(?: for %{EMAILADDRESS:exim_recipient_email})?
+EXIM_UNKNOWN_FIELD (?:[A-Za-z]{1,4}=%{NOTSPACE})
+EXIM_NAMED_FIELDS (?: (?:%{EXIM_REMOTE_HOST}|%{EXIM_INTERFACE}|%{EXIM_PROTOCOL}|%{EXIM_MSG_SIZE}|%{EXIM_HEADER_ID}|%{EXIM_SUBJECT}|%{EXIM_UNKNOWN_FIELD}))*
+
+EXIM_MESSAGE_ARRIVAL %{EXIM_DATE:timestamp} (?:%{EXIM_PID} )?%{EXIM_MSGID:exim_msgid} (?<exim_flags><=) (?:%{EXIM_FLAGS:exim_flags} )?(?<exim_status>[a-z:] )?%{EMAILADDRESS:exim_sender_email}%{EXIM_NAMED_FIELDS}(?: for %{EMAILADDRESS:exim_recipient_email})?
 
 EXIM %{EXIM_MESSAGE_ARRIVAL}

--- a/patterns/legacy/exim
+++ b/patterns/legacy/exim
@@ -1,7 +1,7 @@
 EXIM_MSGID [0-9A-Za-z]{6}-[0-9A-Za-z]{6}-[0-9A-Za-z]{2}
 EXIM_FLAGS (<=|[-=>*]>|[*]{2}|==)
 EXIM_DATE %{YEAR:exim_year}-%{MONTHNUM:exim_month}-%{MONTHDAY:exim_day} %{TIME:exim_time}
-EXIM_PID \[%{POSINT}\]
+EXIM_PID \[%{POSINT:pid}\]
 EXIM_QT ((\d+y)?(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s)?)
 EXIM_EXCLUDE_TERMS (Message is frozen|(Start|End) queue run| Warning: | retry time not reached | no (IP address|host name) found for (IP address|host) | unexpected disconnection while reading SMTP command | no immediate delivery: |another process is handling this message)
 EXIM_REMOTE_HOST (H=(%{NOTSPACE:remote_hostname} )?(\(%{NOTSPACE:remote_heloname}\) )?\[%{IP:remote_host}\])
@@ -11,3 +11,6 @@ EXIM_MSG_SIZE (S=%{NUMBER:exim_msg_size})
 EXIM_HEADER_ID (id=%{NOTSPACE:exim_header_id})
 EXIM_SUBJECT (T=%{QS:exim_subject})
 
+EXIM_MESSAGE_ARRIVAL %{EXIM_DATE:timestamp} (?:%{EXIM_PID} )?%{EXIM_MSGID:exim_msgid} (?<exim_flags><=) (?:%{EXIM_FLAGS:exim_flags} )?(?<exim_status>[a-z:] )?%{EMAILADDRESS:exim_sender_email}(?: (?:%{EXIM_REMOTE_HOST}|%{EXIM_INTERFACE}|%{EXIM_PROTOCOL}|%{EXIM_MSG_SIZE}|%{EXIM_HEADER_ID}|%{EXIM_SUBJECT}|(?:[A-Za-z]{1,4}=%{NOTSPACE})))*(?: for %{EMAILADDRESS:exim_recipient_email})?
+
+EXIM %{EXIM_MESSAGE_ARRIVAL}

--- a/patterns/legacy/exim
+++ b/patterns/legacy/exim
@@ -14,6 +14,6 @@ EXIM_SUBJECT (T=%{QS:exim_subject})
 EXIM_UNKNOWN_FIELD (?:[A-Za-z]{1,4}=%{NOTSPACE})
 EXIM_NAMED_FIELDS (?: (?:%{EXIM_REMOTE_HOST}|%{EXIM_INTERFACE}|%{EXIM_PROTOCOL}|%{EXIM_MSG_SIZE}|%{EXIM_HEADER_ID}|%{EXIM_SUBJECT}|%{EXIM_UNKNOWN_FIELD}))*
 
-EXIM_MESSAGE_ARRIVAL %{EXIM_DATE:timestamp} (?:%{EXIM_PID} )?%{EXIM_MSGID:exim_msgid} (?<exim_flags><=) (?:%{EXIM_FLAGS:exim_flags} )?(?<exim_status>[a-z:] )?%{EMAILADDRESS:exim_sender_email}%{EXIM_NAMED_FIELDS}(?: for %{EMAILADDRESS:exim_recipient_email})?
+EXIM_MESSAGE_ARRIVAL %{EXIM_DATE:timestamp} (?:%{EXIM_PID} )?%{EXIM_MSGID:exim_msgid} (?<exim_flags><=) (?<exim_status>[a-z:] )?%{EMAILADDRESS:exim_sender_email}%{EXIM_NAMED_FIELDS}(?: for %{EMAILADDRESS:exim_recipient_email})?
 
 EXIM %{EXIM_MESSAGE_ARRIVAL}

--- a/patterns/legacy/exim
+++ b/patterns/legacy/exim
@@ -4,7 +4,7 @@ EXIM_DATE %{YEAR:exim_year}-%{MONTHNUM:exim_month}-%{MONTHDAY:exim_day} %{TIME:e
 EXIM_PID \[%{POSINT:pid}\]
 EXIM_QT ((\d+y)?(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s)?)
 EXIM_EXCLUDE_TERMS (Message is frozen|(Start|End) queue run| Warning: | retry time not reached | no (IP address|host name) found for (IP address|host) | unexpected disconnection while reading SMTP command | no immediate delivery: |another process is handling this message)
-EXIM_REMOTE_HOST (H=(%{NOTSPACE:remote_hostname} )?(\(%{NOTSPACE:remote_heloname}\) )?\[%{IP:remote_host}\])
+EXIM_REMOTE_HOST (H=(%{NOTSPACE:remote_hostname} )?(\(%{NOTSPACE:remote_heloname}\) )?\[%{IP:remote_host}\])(?::%{POSINT:remote_port})?
 EXIM_INTERFACE (I=\[%{IP:exim_interface}\](:%{NUMBER:exim_interface_port}))
 EXIM_PROTOCOL (P=%{NOTSPACE:protocol})
 EXIM_MSG_SIZE (S=%{NUMBER:exim_msg_size})

--- a/spec/patterns/exim_spec.rb
+++ b/spec/patterns/exim_spec.rb
@@ -1,0 +1,89 @@
+# encoding: utf-8
+require "spec_helper"
+require "logstash/patterns/core"
+
+describe_pattern 'EXIM' do
+
+  context 'message arrival (old)' do
+
+    let(:message) do
+      "1995-10-31 08:57:53 0tACW1-0005MB-00 <= kryten@dwarf.fict.example H=mailer.fict.example [192.168.123.123] " +
+          "U=exim P=smtp S=5678 id=f828ca60127d8646a0fa75cbf8db9ba3@dwarf.fict.example"
+    end
+
+    it "matches" do
+      expect(grok).to include("timestamp" => "1995-10-31 08:57:53")
+
+      expect(grok).to include("exim_year" => "1995", "exim_month" => "10", "exim_day" => "31", "@version" => "1", "exim_time" => "08:57:53")
+      expect(grok.keys).to_not include("pid")
+      expect(grok).to include("exim_sender_email" => "kryten@dwarf.fict.example")
+      expect(grok).to include("exim_flags" => "<=")
+      expect(grok).to include("exim_msg_size" => "5678")
+      expect(grok).to include("exim_msgid" => "0tACW1-0005MB-00")
+      expect(grok).to include("remote_hostname" => "mailer.fict.example", "remote_host" => "192.168.123.123")
+      expect(grok).to include("protocol" => "smtp")
+      expect(grok).to include("exim_header_id" => "f828ca60127d8646a0fa75cbf8db9ba3@dwarf.fict.example")
+
+      expect(grok).to include("message" => message)
+    end
+
+  end
+
+  context 'message arrival (new)' do
+    let(:message) do
+      '2010-09-13 05:00:13 [1487] 1Ov4tU-0000Nz-Rm <= mailling.list@domain.com ' +
+          'H=mailhost.domain.com [208.42.54.2]:51792 I=[67.215.162.175]:25 P=esmtps X=TLSv1:AES256-SHA:256 CV=no S=21778 ' +
+          'id=384a86a39e83be0d9b3a94d1feb3119f@domain.com T="Daily List: Chameleon" for user@example.com'
+    end
+
+    it "matches" do
+      expect(grok).to include("timestamp" => "2010-09-13 05:00:13") # new
+
+      expect(grok).to include("exim_year" => "2010", "exim_month" => "09", "exim_day" => "13", "exim_time" => "05:00:13")
+      expect(grok).to include("pid" => "1487") # new
+      expect(grok).to include("exim_sender_email" => "mailling.list@domain.com") # new
+      expect(grok).to include("remote_hostname" => "mailhost.domain.com", "remote_host" => "208.42.54.2", "remote_port" => "51792") # (remote_port) new
+      expect(grok).to include("exim_interface" => "67.215.162.175", "exim_interface_port" => "25")
+      expect(grok).to include("protocol" => "esmtps")
+      expect(grok).to include("exim_msg_size" => "21778")
+      expect(grok).to include("exim_header_id" => "384a86a39e83be0d9b3a94d1feb3119f@domain.com")
+      expect(grok).to include("exim_subject" => '"Daily List: Chameleon"')
+      expect(grok).to include("exim_recipient_email" => "user@example.com") # new
+
+      expect(grok).to include("message" => message)
+    end
+
+  end
+
+  context 'message arrival (simple)' do
+
+    let(:message) do
+      '2020-02-11 17:09:46 1j1Z2g-00Faoy-Uh <= example@strawberry.active-ns.com U=example P=local ' +
+          'T="[Examples Galore] Please moderate: \"Hello world!\"" for admin@example.net'
+    end
+
+    it "matches" do
+      expect(grok).to include(
+                          "exim_msgid"=>"1j1Z2g-00Faoy-Uh",
+                          "exim_sender_email"=>"example@strawberry.active-ns.com",
+                          "exim_flags"=>"<=",
+                          "protocol"=>"local",
+                          "exim_subject"=>"\"[Examples Galore] Please moderate: \\\"Hello world!\\\"\""
+                      )
+    end
+
+  end
+
+  context 'delivery failed' do
+
+    let(:message) do
+      '2020-02-11 17:09:47 1j1Z2g-00Faoy-Uh ** admin@example.net R=virtual_aliases: No such person at this address.'
+    end
+
+    it "does not parse" do # matching not implemented
+      expect(grok['tags']).to include("_grokparsefailure")
+    end
+
+  end
+
+end


### PR DESCRIPTION
another day another grok pattern story: this time the *exim* (mail server) patterns seem incomplete.
there seems to be partial sub-patterns and experiments with excluding specific messages which are hard to follow.

in their current (partial) form it's pretty much impossible to even come up with meaningful tests (for ECS).
the proposal here tries to establish a useful (but still minimal) `EXIM` line - for matching "mail arrival" logs (**<=**).

hoping to build exim **ECS support on top of this**.

NOTES:
- changes to existing patterns are backwards compatible
- all presented specs are passing
- there's a mix of %{:grok} and \<regexp\> style named captures
  due the effort to eliminate introducing more `EXIM_xxx` (legacy) names
- other options include only having `EXIM` definition for tests (in a separate file)

HINT: targeting *ecs-wip* branch, these would only get released once the ECS work is complete