### PR TITLE
Feat: allow UNIXPATH to match non-ascii chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
   - Fix: UNIXPATH to avoid DoS on long paths with unmatching chars [#292](https://github.com/logstash-plugins/logstash-patterns-core/pull/292)
 
     For longer paths, a non matching character towards the end of the path would cause the RegExp engine a long time to abort.
-    With this change we're also explicit about not supporting relative paths (using the `PATH` pattern), these won't be properly matched. 
+    With this change we're also explicit about not supporting relative paths (using the `PATH` pattern), these won't be properly matched.
+ 
+  - Feat: allow UNIXPATH to match non-ascii chars [#291](https://github.com/logstash-plugins/logstash-patterns-core/pull/291)
 
 ## 4.1.2
   - Fix some documentation issues

--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -34,7 +34,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths (only absolute paths are matched)
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (/[\w_%!$@:.,+~-]*)+
+UNIXPATH (/[[[:alnum:]]_%!$@:.,+~-]*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]([A-Za-z0-9+\-.]+)+

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -236,7 +236,9 @@ describe "UNIXPATH" do
   end
 
   it "matches paths with non-ascii characters" do
-    expect(grok_match(pattern, '/opt/Čierný_Peter/.中', true)).to pass
+    event = build_event path = '/opt/Čierný_Peter/.中'
+    build_grok('UNIXPATH:path').filter event
+    expect( event.get('path') ).to eql path
   end
 
 end

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -234,6 +234,11 @@ describe "UNIXPATH" do
       expect( event.to_hash['tags'] ).to include '_grokparsefailure'
     end
   end
+
+  it "matches paths with non-ascii characters" do
+    expect(grok_match(pattern, '/opt/Čierný_Peter/.中', true)).to pass
+  end
+
 end
 
 describe "WINPATH" do

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -266,6 +266,10 @@ describe "WINPATH" do
     expect(grok_match(pattern, 'C://', true)).to_not pass
   end
 
+  it "matches paths with non-ascii characters" do
+    expect(grok_match(pattern, 'C:\\Čierný Peter\\.中.exe', true)).to pass
+  end
+
   context 'relative paths' do
 
     it "should not match" do


### PR DESCRIPTION
`WINPATH` matches paths containin non-ascii chars but `UNIXPATH` does not, which makes `PATH` inconsistent.

e.g. `/var/vtaky/ďateľ/čierny` is a valid path name on Linux and should be matched ... 

The issue was discovered while bumping into #159 a longer path had chars with diacritics towards the end (such as `/home/eaeaea/data/import/Sample_xyz_lé_é_c b` from #292), this not only did not match but actually lead to a slow ingestion process as all of these entries needed to abort the extensive back-tracking with a grok timeout.

(follow-up on https://github.com/logstash-plugins/logstash-patterns-core/pull/292)