### PR TITLE
Fix: UNIXPATH to avoid DoS on long paths with unmatching chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
   - Fix: Java stack trace's JAVAFILE to better match generated names
   - Fix: match Information/INFORMATION in LOGLEVEL [#274](https://github.com/logstash-plugins/logstash-patterns-core/pull/274)
   - Fix: NAGIOS TIMEPERIOD unknown (from/to) field matching [#275](https://github.com/logstash-plugins/logstash-patterns-core/pull/275)
-  - Fix: HTTPD access log parse failure on missing response [#282](https://github.com/logstash-plugins/logstash-patterns-core/pull/282) 
+  - Fix: HTTPD access log parse failure on missing response [#282](https://github.com/logstash-plugins/logstash-patterns-core/pull/282)
+  - Fix: UNIXPATH to avoid DoS on long paths with unmatching chars [#292](https://github.com/logstash-plugins/logstash-patterns-core/pull/292)
+
+    For longer paths, a non matching character towards the end of the path would cause the RegExp engine a long time to abort.
+    With this change we're also explicit about not supporting relative paths (using the `PATH` pattern), these won't be properly matched. 
 
 ## 4.1.2
   - Fix some documentation issues

--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -34,7 +34,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (/([\w_%!$@:.,+~-]+|\\.)*)+
+UNIXPATH (/[\w_%!$@:.,+~-]+)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]([A-Za-z0-9+\-.]+)+

--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -32,7 +32,7 @@ HOSTNAME \b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62
 IPORHOST (?:%{IP}|%{HOSTNAME})
 HOSTPORT %{IPORHOST}:%{POSINT}
 
-# paths
+# paths (only absolute paths are matched)
 PATH (?:%{UNIXPATH}|%{WINPATH})
 UNIXPATH (/[\w_%!$@:.,+~-]*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))

--- a/patterns/grok-patterns
+++ b/patterns/grok-patterns
@@ -34,7 +34,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (/[\w_%!$@:.,+~-]+)+
+UNIXPATH (/[\w_%!$@:.,+~-]*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]([A-Za-z0-9+\-.]+)+

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -118,7 +118,7 @@ describe "UNIXPATH" do
   context "dotted path" do
 
     it "should match path containing ." do
-      expect(grok_match(pattern, '/some/./path')).to pass
+      expect(grok_match(pattern, '/some/./path/')).to pass
       expect(grok_match(pattern, '/some/../path')).to pass
       expect(grok_match(pattern, '/../.')).to pass
       expect(grok_match(pattern, '/.')).to pass
@@ -153,15 +153,18 @@ describe "UNIXPATH" do
 
   context "separators" do
 
-    it "should match" do
+    it "should match root" do
       expect(grok_match(pattern, '/')).to pass
     end
 
-    it "should not match" do
-      expect(grok_match(pattern, '//')).to_not pass
-      expect(grok_match(pattern, '/a//')).to_not pass
-      expect(grok_match(pattern, '/a/b//')).to_not pass
-      expect(grok_match(pattern, '/a//b')).to_not pass
+    it "should match" do # NOTE: we did not match these in < 4.2.0
+      expect(grok_match(pattern, '//')).to pass
+      expect(grok_match(pattern, '//00')).to pass
+      expect(grok_match(pattern, '///a')).to pass
+      expect(grok_match(pattern, '/a//')).to pass
+      expect(grok_match(pattern, '~/b//')).to pass
+      expect(grok_match(pattern, 'a//b')).to pass
+      expect(grok_match(pattern, '///a//b/c///')).to pass
     end
 
   end

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -108,11 +108,23 @@ describe "UNIXPATH" do
 
   context "when using comma separators and other regexp" do
 
+    let(:pattern) { '((a=(?<a>%{UNIXPATH})?|b=(?<b>%{UNIXPATH})?)(,\s)?)+' }
+
+    let(:grok) do
+      grok = LogStash::Filters::Grok.new("match" => ["message", pattern])
+      grok.register
+      grok
+    end
+
     let(:value) { 'a=/some/path, b=/some/other/path' }
 
-    it "should match the path" do
-      expect(grok_match(pattern,value)).to pass
+    it "should match both paths" do # but does not
+      event = build_event(value)
+      grok.filter(event)
+      expect( event.to_hash['a'] ).to eql '/some/path,'
+      expect( event.to_hash['b'] ).to be nil
     end
+
   end
 
   context "dotted path" do

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -204,6 +204,12 @@ describe "UNIXPATH" do
       expect(grok_match(pattern, '///a//b/c///', true)).to pass
     end
 
+    it "should not match windows separator" do
+      expect(grok_match(pattern, "\\a", true)).to_not pass
+      expect(grok_match(pattern, '/0\\', true)).to_not pass
+      expect(grok_match(pattern, "/a\\b", true)).to_not pass
+    end
+
   end
 
   context "long path" do
@@ -229,6 +235,65 @@ describe "UNIXPATH" do
     end
   end
 end
+
+describe "WINPATH" do
+
+  let(:pattern) { 'WINPATH' }
+  let(:value)   { 'C:\\foo\\bar' }
+
+  it "should match the path" do
+    expect(grok_match(pattern, value, true)).to pass
+  end
+
+  it "should match root path" do
+    expect(grok_match(pattern, 'C:\\', true)).to pass
+    expect(grok_match(pattern, 'C:\\\\', true)).to pass
+    expect(grok_match(pattern, 'a:\\', true)).to pass
+    expect(grok_match(pattern, 'x:\\\\', true)).to pass
+  end
+
+  it "should match paths with spaces" do
+    expect(grok_match(pattern, 'C:\\Documents and Settings\\Public', true)).to pass
+    expect(grok_match(pattern, 'C:\\\\Users\\\\Public\\\\.Mozilla Firefox', true)).to pass
+  end
+
+  it "should not match unix-style paths" do
+    expect(grok_match(pattern, '/foo', true)).to_not pass
+    expect(grok_match(pattern, '//C/path', true)).to_not pass
+    expect(grok_match(pattern, '/', true)).to_not pass
+    expect(grok_match(pattern, '/foo/bar', true)).to_not pass
+    expect(grok_match(pattern, '/..', true)).to_not pass
+    expect(grok_match(pattern, 'C://', true)).to_not pass
+  end
+
+  context 'relative paths' do
+
+    it "should not match" do
+      expect(grok_match(pattern, 'a\\bar', true)).to_not pass
+      expect(grok_match(pattern, 'foo\\bar', true)).to_not pass
+      expect(grok_match(pattern, 'C\\A\\B', true)).to_not pass
+      expect(grok_match(pattern, 'C\\\\0', true)).to_not pass
+      expect(grok_match(pattern, '.\\0', true)).to_not pass
+      expect(grok_match(pattern, '..\\', true)).to_not pass
+      expect(grok_match(pattern, '...\\-', true)).to_not pass
+      expect(grok_match(pattern, '.\\', true)).to_not pass
+      expect(grok_match(pattern, '.\\,', true)).to_not pass
+      expect(grok_match(pattern, '..\\', true)).to_not pass
+      expect(grok_match(pattern, '.a\\', true)).to_not pass
+    end
+
+    it "should not match expression wout separator" do
+      expect(grok_match(pattern, '.')).to_not pass
+      expect(grok_match(pattern, '..')).to_not pass
+      expect(grok_match(pattern, '...')).to_not pass
+      expect(grok_match(pattern, 'C:')).to_not pass
+      expect(grok_match(pattern, 'C')).to_not pass
+    end
+
+  end
+
+end
+
 
 describe "URIPROTO" do
   let(:pattern) { 'URIPROTO' }

--- a/spec/patterns/core_spec.rb
+++ b/spec/patterns/core_spec.rb
@@ -115,6 +115,57 @@ describe "UNIXPATH" do
     end
   end
 
+  context "dotted path" do
+
+    it "should match path containing ." do
+      expect(grok_match(pattern, '/some/./path')).to pass
+      expect(grok_match(pattern, '/some/../path')).to pass
+      expect(grok_match(pattern, '/../.')).to pass
+      expect(grok_match(pattern, '/.')).to pass
+      expect(grok_match(pattern, '/..')).to pass
+      expect(grok_match(pattern, '/...')).to pass
+
+      expect(grok_match(pattern, 'a/./b/c')).to pass
+      expect(grok_match(pattern, ',/.')).to pass
+      expect(grok_match(pattern, '+/.../')).to pass
+    end
+
+    it "should match path starting with ." do
+      expect(grok_match(pattern, '../0')).to pass
+      expect(grok_match(pattern, './~')).to pass
+      expect(grok_match(pattern, '.../-')).to pass
+      expect(grok_match(pattern, './')).to pass
+      expect(grok_match(pattern, './,')).to pass
+      expect(grok_match(pattern, '../')).to pass
+      expect(grok_match(pattern, '.a/')).to pass
+      expect(grok_match(pattern, '.~/')).to pass
+    end
+
+    it "should not match if there's no separator" do
+      expect(grok_match(pattern, '.')).to_not pass
+      expect(grok_match(pattern, '..')).to_not pass
+      expect(grok_match(pattern, '...')).to_not pass
+      expect(grok_match(pattern, '.,')).to_not pass
+      expect(grok_match(pattern, '.-')).to_not pass
+    end
+
+  end
+
+  context "separators" do
+
+    it "should match" do
+      expect(grok_match(pattern, '/')).to pass
+    end
+
+    it "should not match" do
+      expect(grok_match(pattern, '//')).to_not pass
+      expect(grok_match(pattern, '/a//')).to_not pass
+      expect(grok_match(pattern, '/a/b//')).to_not pass
+      expect(grok_match(pattern, '/a//b')).to_not pass
+    end
+
+  end
+
   context "long path" do
 
     let(:grok) do


### PR DESCRIPTION
Using `PATH` and namely it's sub-pattern `UNIXPATH` can lead to DoS (due regular expression back-tracking).

Sample one line reproducer (pattern is the original expanded `UNIXPATH`):
`ruby -e '/(\/([\w_%!$@:.,+~-]+|\\\\.)*)+ /.match "/opt/abcdef/1/.22/3:3+3/foo@BAR/X-Y+Z/~Sample_l_&^_c b"'`

... the important part is the non-matching `&^` sequence at the end.

Currently `UNIXPATH` does not handle unicode chars (separate issue), this issue (100% CPU) was discovered with non-ascii chars at the end: `/home/eaeaea/data/import/Sample_xyz_lé_é_c b`

~~Also to be noted that the pattern does not interrupt properly, using a timeout, thus there isn't a good work-around except not using or redefining `PATH/UNIXPATH`.~~

resolves https://github.com/logstash-plugins/logstash-patterns-core/issues/159