### PR TITLE
Build: revert the need to use a git source

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-sudo yum install -y git

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,3 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
-
-# TODO till filter grok with ECS support is released :
-gem 'logstash-filter-grok', git: 'https://github.com/kares/logstash-filter-grok.git', ref: 'ecs-1-support'


### PR DESCRIPTION
... after https://github.com/logstash-plugins/logstash-filter-grok/pull/162 (logstash-filter-grok is released)
