### PR TITLE
Fix: incorrect syslog (priority) field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.3.1
+
+- Fix: incorrect syslog (priority) field name [#303](https://github.com/logstash-plugins/logstash-patterns-core/pull/303)
+- Fix: missed `ciscotag` field ECS-ification (`cisco.asa.tag`) for the `CISCO_TAGGED_SYSLOG` pattern 
+
 ## 4.3.0
 
 With **4.3.0** we're introducing a new set of pattern definitions compliant with Elastic Common Schema (ECS), on numerous 

--- a/logstash-patterns-core.gemspec
+++ b/logstash-patterns-core.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-patterns-core'
-  s.version         = '4.3.0'
+  s.version         = '4.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Patterns to be used in logstash"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/patterns/ecs-v1/firewalls
+++ b/patterns/ecs-v1/firewalls
@@ -4,7 +4,7 @@ NETSCREENSESSIONLOG %{SYSLOGTIMESTAMP:timestamp} %{IPORHOST:[observer][hostname]
 # :long - %{INT:[destination][bytes]:int}
 
 #== Cisco ASA ==
-CISCO_TAGGED_SYSLOG ^<%{POSINT:[log][syslog][facility][code]:int}>%{CISCOTIMESTAMP:timestamp}( %{SYSLOGHOST:[host][hostname]})? ?: %%{CISCOTAG:ciscotag}:
+CISCO_TAGGED_SYSLOG ^<%{POSINT:[log][syslog][priority]:int}>%{CISCOTIMESTAMP:timestamp}( %{SYSLOGHOST:[host][hostname]})? ?: %%{CISCOTAG:[cisco][asa][tag]}:
 CISCOTIMESTAMP %{MONTH} +%{MONTHDAY}(?: %{YEAR})? %{TIME}
 CISCOTAG [A-Z0-9]+-%{INT}-(?:[A-Z0-9_]+)
 # Common Particles

--- a/patterns/ecs-v1/linux-syslog
+++ b/patterns/ecs-v1/linux-syslog
@@ -9,7 +9,7 @@ CRONLOG %{SYSLOGBASE} \(%{USER:[user][name]}\) %{CRON_ACTION:[system][cron][acti
 SYSLOGLINE %{SYSLOGBASE2} %{GREEDYDATA:message}
 
 # IETF 5424 syslog(8) format (see http://www.rfc-editor.org/info/rfc5424)
-SYSLOG5424PRI <%{NONNEGINT:[log][syslog][facility][code]:int}>
+SYSLOG5424PRI <%{NONNEGINT:[log][syslog][priority]:int}>
 SYSLOG5424SD \[%{DATA}\]+
 SYSLOG5424BASE %{SYSLOG5424PRI}%{NONNEGINT:[system][syslog][version]} +(?:-|%{TIMESTAMP_ISO8601:timestamp}) +(?:-|%{IPORHOST:[host][hostname]}) +(?:-|%{SYSLOG5424PRINTASCII:[process][name]}) +(?:-|%{POSINT:[process][pid]:int}) +(?:-|%{SYSLOG5424PRINTASCII:[event][code]}) +(?:-|%{SYSLOG5424SD:[system][syslog][structured_data]})?
 

--- a/spec/patterns/firewalls_spec.rb
+++ b/spec/patterns/firewalls_spec.rb
@@ -595,6 +595,44 @@ describe_pattern "CISCOFW733100", ['legacy', 'ecs-v1'] do
 
 end
 
+describe_pattern "CISCO_TAGGED_SYSLOG", ['legacy', 'ecs-v1'] do
+
+  let(:message) { "<191>Jan 24 11:28:30.407: %LINEPROTO-5-UPDOWN: Line protocol on Interface GigabitEthernet0/0, changed state to down" }
+
+  it 'matches' do
+    expect(subject).to include("timestamp"=>'Jan 24 11:28:30.407')
+    if ecs_compatibility?
+      expect(subject).to include('log' => {'syslog' => {'priority' => 191}})
+      expect(subject).to include('cisco' => {'asa' => {'tag' => 'LINEPROTO-5-UPDOWN'}})
+    else
+      expect(subject).to include("syslog_pri"=>'191')
+      expect(subject).to include("ciscotag"=>'LINEPROTO-5-UPDOWN')
+    end
+  end
+
+  context 'with host' do
+
+    let(:message) do
+      '<191>Aug  1 14:01:20 abc-asa1: %ASA-6-302013: Built outbound TCP connection 906569140 for out-v1101:10.125.126.86/2010 (10.125.126.86/2010) to ent-v1124:100.100.100.111/51444 (10.125.1.11/37785)'
+    end
+
+    it 'matches' do
+      expect(subject).to include("timestamp"=>'Aug  1 14:01:20')
+      if ecs_compatibility?
+        expect(subject).to include('log' => {'syslog' => {'priority' => 191}})
+        expect(subject).to include('host' => {'hostname' => 'abc-asa1'})
+        expect(subject).to include('cisco' => {'asa' => {'tag' => 'ASA-6-302013'}})
+      else
+        expect(subject).to include("syslog_pri"=>'191')
+        expect(subject).to include("sysloghost"=>'abc-asa1')
+        expect(subject).to include("ciscotag"=>'ASA-6-302013')
+      end
+    end
+
+  end
+
+end
+
 
 describe_pattern 'SFW2', ['legacy', 'ecs-v1'] do
 

--- a/spec/patterns/netscreen_spec.rb
+++ b/spec/patterns/netscreen_spec.rb
@@ -98,7 +98,7 @@ describe_pattern "NETSCREENSESSIONLOG", ['legacy', 'ecs-v1'] do
     context "(with session id)" do
 
       let(:message) do
-        super + ' session_id=0 reason=Traffic Denied'
+        super() + ' session_id=0 reason=Traffic Denied'
       end
 
       it 'matches (in ECS mode)' do

--- a/spec/patterns/syslog_spec.rb
+++ b/spec/patterns/syslog_spec.rb
@@ -95,7 +95,7 @@ describe_pattern "SYSLOG5424LINE", ['legacy', 'ecs-v1'] do
     message = "<174>1 2016-11-14T09:49:23+01:00 10.23.16.6 named 2255 - -  info: client 10.23.56.93#63295 (i1.tmg.com): query: i1.tmg.com IN A + (10.23.4.13)"
     match = grok_match pattern, message
     if ecs_compatibility?
-      expect(match).to include("log" => { "syslog" => { "facility" => { "code" => 174 }}})
+      expect(match).to include("log" => { "syslog" => { "priority" => 174 }})
       expect(match).to include("host" => { "hostname" => "10.23.16.6"})
       expect(match).to include("process" => { "name" => "named", "pid" => 2255 })
       expect(match).to include("system" => { "syslog" => { "version" => "1" }})


### PR DESCRIPTION
a follow-up on https://github.com/logstash-plugins/logstash-patterns-core/pull/297

- for `SYSLOG5424PRI` we clearly want `log.syslog.priority`
- same for `CISCO_TAGGED_SYSLOG`
  this field slipped through ECS-ification (no proper use-case with the specific pattern files e.g. `CISCOFW104001`)
  we clearly missed ECS-ifing the `ciscotag` field name (as `cisco.asa.tag`)