### PR TITLE
Update SYSLOG5224BASE for ECS 8.2

### DIFF
--- a/patterns/ecs-v1/linux-syslog
+++ b/patterns/ecs-v1/linux-syslog
@@ -11,6 +11,6 @@ SYSLOGLINE %{SYSLOGBASE2} %{GREEDYDATA:message}
 # IETF 5424 syslog(8) format (see http://www.rfc-editor.org/info/rfc5424)
 SYSLOG5424PRI <%{NONNEGINT:[log][syslog][priority]:int}>
 SYSLOG5424SD \[%{DATA}\]+
-SYSLOG5424BASE %{SYSLOG5424PRI}%{NONNEGINT:[system][syslog][version]} +(?:-|%{TIMESTAMP_ISO8601:timestamp}) +(?:-|%{IPORHOST:[host][hostname]}) +(?:-|%{SYSLOG5424PRINTASCII:[process][name]}) +(?:-|%{POSINT:[process][pid]:int}) +(?:-|%{SYSLOG5424PRINTASCII:[event][code]}) +(?:-|%{SYSLOG5424SD:[system][syslog][structured_data]})?
+SYSLOG5424BASE %{SYSLOG5424PRI}%{NONNEGINT:[log][syslog][version]} +(?:-|%{TIMESTAMP_ISO8601:timestamp}) +(?:-|%{IPORHOST:[host][hostname]}) +(?:-|%{SYSLOG5424PRINTASCII:[process][name]}) +(?:-|%{POSINT:[process][pid]:int}) +(?:-|%{SYSLOG5424PRINTASCII:[event][code]}) +(?:-|%{SYSLOG5424SD:[log][syslog][structured_data]})?
 
 SYSLOG5424LINE %{SYSLOG5424BASE} +%{GREEDYDATA:message}


### PR DESCRIPTION
In ECS 8.2.0 multiple syslog fields (such as `log.syslog.version` and `log.syslog.structured_data`) have been introduced (https://github.com/elastic/ecs/pull/1793). 

The current `SYSLOG5424BASE` pattern stores some of the syslog fileds in the `system` field. This field is not defined in the ECS standard. 

This PR changes 2 fields of the SYSLOG5242BASE pattern, to use the newly defined fields of the ECS 8.2 definition.

* `system.syslog.version` -> `log.syslog.version`
* `system.syslog.structured_data` -> `log.syslog.structured_data`

The other fields of the `SYSLOG5242BASE` have been left unchanged, because changing `host.hostname` to `log.syslog.hostname`) would introduce a breaking change. I can image many pipelines rely on the `host.hostname` field.