### PR TITLE
Improve `HTTPD24_ERRORLOG` parsing of proxy errors

### DIFF
--- a/patterns/ecs-v1/httpd
+++ b/patterns/ecs-v1/httpd
@@ -8,7 +8,7 @@ HTTPD_COMBINEDLOG %{HTTPD_COMMONLOG} "(?:-|%{DATA:[http][request][referrer]})" "
 
 # Error logs
 HTTPD20_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[%{LOGLEVEL:[log][level]}\] (?:\[client %{IPORHOST:[source][address]}\] )?%{GREEDYDATA:message}
-HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[(?:%{WORD:[apache][error][module]})?:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]:int}(:tid %{INT:[process][thread][id]:int})?\](?: \(%{POSINT:[apache][error][proxy][error][code]?}\)%{DATA:[apache][error][proxy][error][message]}:)?(?: \[client %{IPORHOST:[source][address]}(?::%{POSINT:[source][port]:int})?\])?(?: %{DATA:[error][code]}:)? %{GREEDYDATA:message}
+HTTPD24_ERRORLOG \[%{HTTPDERROR_DATE:timestamp}\] \[(?:%{WORD:[apache][error][module]})?:%{LOGLEVEL:[log][level]}\] \[pid %{POSINT:[process][pid]:int}(:tid %{INT:[process][thread][id]:int})?\](?: \(%{POSINT:[apache][error][proxy][error][code]}\)%{DATA:[apache][error][proxy][error][message]}:)?(?: \[client %{IPORHOST:[source][address]}(?::%{NONNEGINT:[source][port]:int})?\])?(?: %{DATA:[error][code]}:)? %{GREEDYDATA:message}
 # :long - %{INT:[process][thread][id]:int}
 HTTPD_ERRORLOG %{HTTPD20_ERRORLOG}|%{HTTPD24_ERRORLOG}
 

--- a/spec/patterns/httpd_spec.rb
+++ b/spec/patterns/httpd_spec.rb
@@ -279,6 +279,24 @@ describe_pattern "HTTPD_ERRORLOG", ['legacy', 'ecs-v1'] do
     end
   end
 
+  context "a httpd 2.4 proxy message" do
+    let(:message) do
+      "[Fri Sep 13 20:16:16.614584 2024] [proxy_fcgi:error] [pid 74738:tid 74765] (70008)Partial results are valid but processing is incomplete: [client 203.0.113.1:0] AH01075: Error dispatching request to : (reading input brigade)"
+    end
+
+    it "matches" do
+      expect(grok).to include('timestamp' => 'Fri Sep 13 20:16:16.614584 2024')
+      if ecs_compatibility?
+        expect(grok).to include("apache" => {"error" => {"module" => "proxy_fcgi", "proxy" => {"error" => {"code" => "70008", "message" => "Partial results are valid but processing is incomplete"}}}})
+        expect(grok).to include("log" => {"level" => "error"})
+        expect(grok).to include("process" => {"pid" => 74738, "thread" => {"id" => 74765}})
+        expect(grok).to include("source" => {"address" => "203.0.113.1", "port" => 0})
+        expect(grok).to include("error" => {"code" => "AH01075"})
+        expect(grok).to include("message" => [message, "Error dispatching request to : (reading input brigade)"])
+      end
+    end
+  end
+
   context 'a debug message' do
     let(:message) do
       '[Fri Feb 01 22:03:08.319124 2019] [authz_core:debug] [pid 9:tid 140597881775872] mod_authz_core.c(820): [client 172.17.0.1:50752] AH01626: authorization result of <RequireAny>: granted'


### PR DESCRIPTION
## Problem
Currently, `HTTPD24_ERRORLOG` fails to correctly parse this message:

> [Fri Sep 13 20:16:16.614584 2024] [proxy_fcgi:error] [pid 74738:tid 74765] (70008)Partial results are valid but processing is incomplete: [client 203.0.113.1:0] AH01075: Error dispatching request to : (reading input brigade)

## Analysis
1. This clause appears to have a stray question mark:

   > %{POSINT:[apache][error][proxy][error][code]?}

2. This clause only allows ports 1 and greater (whereas the above log message indicates port 0):

   > %{POSINT:[source][port]:int}

## Proposed change
1. Remove stray question mark
2. Change `POSINT` to `NONNEGINT`